### PR TITLE
[WIP] Resolve #157 - Allow NaNs in Random*Samplers

### DIFF
--- a/imblearn/base.py
+++ b/imblearn/base.py
@@ -44,7 +44,8 @@ class SamplerMixin(six.with_metaclass(ABCMeta, BaseEstimator)):
 
         self.ratio = ratio
         self.logger = logging.getLogger(__name__)
-
+        self._force_all_finite = True
+        
     def fit(self, X, y):
         """Find the classes statistics before to perform sampling.
 
@@ -64,12 +65,13 @@ class SamplerMixin(six.with_metaclass(ABCMeta, BaseEstimator)):
         """
 
         # Check the consistency of X and y
-        X, y = check_X_y(X, y)
+        X, y = check_X_y(X, y, force_all_finite=self._force_all_finite)
 
         self.min_c_ = None
         self.maj_c_ = None
         self.stats_c_ = {}
         self.X_shape_ = None
+        
 
         if hasattr(self, 'ratio'):
             self._validate_ratio()
@@ -134,7 +136,7 @@ class SamplerMixin(six.with_metaclass(ABCMeta, BaseEstimator)):
         """
 
         # Check the consistency of X and y
-        X, y = check_X_y(X, y)
+        X, y = check_X_y(X, y, force_all_finite=self._force_all_finite)
 
         # Check that the data have been fitted
         if not hasattr(self, 'stats_c_'):

--- a/imblearn/over_sampling/random_over_sampler.py
+++ b/imblearn/over_sampling/random_over_sampler.py
@@ -71,9 +71,9 @@ class RandomOverSampler(BaseMulticlassSampler):
     def __init__(self,
                  ratio='auto',
                  random_state=None):
-
         super(RandomOverSampler, self).__init__(ratio=ratio)
         self.random_state = random_state
+        self._force_all_finite = False
 
     def _sample(self, X, y):
         """Resample the dataset.

--- a/imblearn/over_sampling/tests/test_random_over_sampler.py
+++ b/imblearn/over_sampling/tests/test_random_over_sampler.py
@@ -200,3 +200,23 @@ def test_multiclass_fit_sample():
     assert_equal(count_y_res[0], 5)
     assert_equal(count_y_res[1], 5)
     assert_equal(count_y_res[2], 5)
+    
+    
+def test_multiclass_fit_sample_with_nans():
+    """Test fit sample method with multiclass target"""
+
+    # Make y to be multiclass
+    y = Y.copy()
+    y[5] = 2
+    y[6] = 2
+    X[0, 0] = np.nan
+    X[1, 0] = np.nan
+    # Resample the data
+    ros = RandomOverSampler(random_state=RND_SEED)
+    X_resampled, y_resampled = ros.fit_sample(X, y)
+
+    # Check the size of y
+    count_y_res = Counter(y_resampled)
+    assert_equal(count_y_res[0], 5)
+    assert_equal(count_y_res[1], 5)
+    assert_equal(count_y_res[2], 5)

--- a/imblearn/under_sampling/random_under_sampler.py
+++ b/imblearn/under_sampling/random_under_sampler.py
@@ -79,6 +79,7 @@ class RandomUnderSampler(BaseMulticlassSampler):
         self.return_indices = return_indices
         self.random_state = random_state
         self.replacement = replacement
+        self._force_all_finite = False
 
     def _sample(self, X, y):
         """Resample the dataset.

--- a/imblearn/under_sampling/tests/test_random_under_sampler.py
+++ b/imblearn/under_sampling/tests/test_random_under_sampler.py
@@ -211,3 +211,23 @@ def test_multiclass_fit_sample():
     assert_equal(count_y_res[0], 2)
     assert_equal(count_y_res[1], 2)
     assert_equal(count_y_res[2], 2)
+    
+    
+def test_multiclass_fit_sample_with_nans():
+    """Test fit sample method with multiclass target"""
+
+    # Make y to be multiclass
+    y = Y.copy()
+    y[5] = 2
+    y[6] = 2
+    X[0, 0] = np.nan
+    X[1, 0] = np.nan
+    # Resample the data
+    ros = RandomUnderSampler(random_state=RND_SEED)
+    X_resampled, y_resampled = ros.fit_sample(X, y)
+
+    # Check the size of y
+    count_y_res = Counter(y_resampled)
+    assert_equal(count_y_res[0], 2)
+    assert_equal(count_y_res[1], 2)
+    assert_equal(count_y_res[2], 2)


### PR DESCRIPTION
With this PR I tried to address the #157 issue, but doing this the `check_estimator` test is falling because internally calls the `check_estimators_nan_inf` which desn't accept `NaNs` `if name not in ['Imputer']` and raises error.

We could skip the two tests that failing for this reason and open an issue in the `scikit-learn` repository to get feedback like this scikit-learn/scikit-learn#6981. Thoughts @dvro @glemaitre ?
