### PR TITLE
[MRG] Remove useless code in SMOTE_ENN

### DIFF
--- a/imblearn/combine/smote_enn.py
+++ b/imblearn/combine/smote_enn.py
@@ -156,12 +156,6 @@ class SMOTEENN(BaseBinarySampler):
 
         super(SMOTEENN, self).fit(X, y)
 
-        # Annonce deprecation if necessary
-        if self.size_ngh is not None:
-            warnings.warn('`size_ngh` will be replaced in version 0.4. Use'
-                          ' `n_neighbors` instead.', DeprecationWarning)
-            self.n_neighbors = self.size_ngh
-
         # Fit using SMOTE
         self.sm.fit(X, y)
 

--- a/imblearn/under_sampling/edited_nearest_neighbours.py
+++ b/imblearn/under_sampling/edited_nearest_neighbours.py
@@ -601,7 +601,7 @@ class AllKNN(BaseMulticlassSampler):
         for curr_size_ngh in range(1, self.n_neighbors + 1):
             self.logger.debug('Apply ENN size_ngh #%s', curr_size_ngh)
             # updating ENN size_ngh
-            self.enn_.size_ngh = curr_size_ngh
+            self.enn_.n_neighbors = curr_size_ngh
 
             if self.return_indices:
                 X_enn, y_enn, idx_enn = self.enn_.fit_sample(X_, y_)


### PR DESCRIPTION
Remove the already declared warning, as stated in issue #173, plus replace a `size_ngh` variable by its successor `n_neighbors`.