### PR TITLE
[MRG] CondensedNearestNeighbour ValueError fix #208

### DIFF
--- a/imblearn/under_sampling/condensed_nearest_neighbour.py
+++ b/imblearn/under_sampling/condensed_nearest_neighbour.py
@@ -244,7 +244,7 @@ class CondensedNearestNeighbour(BaseMulticlassSampler):
                                   np.flatnonzero(pred_S_y == S_y)))
 
             # Find the misclassified S_y
-            sel_x = np.squeeze(S_x[idx_maj_sample, :])
+            sel_x = S_x[idx_maj_sample, :]
             sel_y = S_y[idx_maj_sample]
 
             # The indexes found are relative to the current class, we need to


### PR DESCRIPTION
Fixes #208 
It seems, that np.squeeze was redundant, when idx_maj_sample is only one element, it makes S_x 1 dimensional and causes error