### PR TITLE
[MRG+1] idx_under should be expressed by indices of parameter X

### DIFF
--- a/imblearn/under_sampling/tests/test_one_sided_selection.py
+++ b/imblearn/under_sampling/tests/test_one_sided_selection.py
@@ -105,7 +105,7 @@ def test_oss_fit_sample_with_indices():
                      [-0.43877303, 1.07366684], [-0.85795321, 0.82980738],
                      [-0.30126957, -0.66268378], [0.20246714, -0.34727125]])
     y_gt = np.array([0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1])
-    idx_gt = np.array([0, 3, 9, 12, 13, 14, 1, 2, 5, 6, 7, 10])
+    idx_gt = np.array([0, 3, 9, 12, 13, 14, 1, 2, 5, 6, 8, 11])
     assert_array_equal(X_resampled, X_gt)
     assert_array_equal(y_resampled, y_gt)
     assert_array_equal(idx_under, idx_gt)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
With current implementation idx_under is concatenated with idx_under,
idx_maj_sample and idx_tmp. And idx_maj_sample is created with
indices of majority class so wrong indices will be created.
This patch fixes the way of creating idx_under.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
