### PR TITLE
Changed n_neighbours to n_neighbors

### DIFF
--- a/imblearn/over_sampling/adasyn.py
+++ b/imblearn/over_sampling/adasyn.py
@@ -37,7 +37,7 @@ class ADASYN(BaseBinarySampler):
         NOTE: `k` is deprecated from 0.2 and will be replaced in 0.4
         Use ``n_neighbors`` instead.
 
-    n_neighbours : int int or object, optional (default=5)
+    n_neighbors : int int or object, optional (default=5)
         If int, number of nearest neighbours to used to construct
         synthetic samples.
         If object, an estimator that inherits from


### PR DESCRIPTION
Changed n_neighbours to n_neighbors in Parameters description

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### What does this implement/fix? Explain your changes.
Just spelling of parameter n_neighbors is corrected. Previously it was n_neighbours in Parameter description. It was confusion to me, when I wanted to use the params in GridSearch. And used the parameters from the description.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
