### PR TITLE
NeighbourhoodCleaningRule fix

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,6 +24,7 @@ Bug fixes
 - Fixed a bug in :class:`pipeline.Pipeline`, solve to embed `Pipeline` in other `Pipeline. By `Christos Aridas`_ .
 - Fixed a bug in :class:`pipeline.Pipeline`, solve the issue to put to sampler in the same `Pipeline`. By `Christos Aridas`_ .
 - Fixed a bug in :class:`under_sampling.CondensedNeareastNeigbour`, correction of the shape of `sel_x` when only one sample is selected. By `Aliaksei Halachkin`_.
+- Fixed a bug in :class:`under_sampling.NeighbourhoodCleaningRule`, selecting neighbours instead of minority class misclassified samples. By `Aleksandr Loskutov`_.
 
 New features
 ~~~~~~~~~~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -118,3 +118,4 @@ New methods
 .. _Dayvid Oliveira: https://github.com/dvro
 .. _Francois Magimel: https://github.com/Linkid
 .. _Aliaksei Halachkin: https://github.com/honeyext
+.. _Aleksandr Loskutov: https://github.com/loskutyan

--- a/imblearn/under_sampling/neighbourhood_cleaning_rule.py
+++ b/imblearn/under_sampling/neighbourhood_cleaning_rule.py
@@ -199,8 +199,8 @@ class NeighbourhoodCleaningRule(BaseMulticlassSampler):
             # If the minority class remove the majority samples
             if key == self.min_c_:
                 # Get the index to exclude
-                idx_to_exclude += nnhood_idx[np.nonzero(np.logical_not(nnhood_label[
-                    np.flatnonzero(nnhood_bool)]))].tolist()
+                idx_to_exclude += nnhood_idx[np.nonzero(np.logical_not(
+                    nnhood_label[np.flatnonzero(nnhood_bool)]))].tolist()
             else:
                 # Get the index to exclude
                 idx_to_exclude += idx_sub_sample[np.nonzero(

--- a/imblearn/under_sampling/neighbourhood_cleaning_rule.py
+++ b/imblearn/under_sampling/neighbourhood_cleaning_rule.py
@@ -199,8 +199,8 @@ class NeighbourhoodCleaningRule(BaseMulticlassSampler):
             # If the minority class remove the majority samples
             if key == self.min_c_:
                 # Get the index to exclude
-                idx_to_exclude += nnhood_idx[np.nonzero(nnhood_label[
-                    np.flatnonzero(nnhood_bool)])].tolist()
+                idx_to_exclude += nnhood_idx[np.nonzero(np.logical_not(nnhood_label[
+                    np.flatnonzero(nnhood_bool)]))].tolist()
             else:
                 # Get the index to exclude
                 idx_to_exclude += idx_sub_sample[np.nonzero(

--- a/imblearn/under_sampling/neighbourhood_cleaning_rule.py
+++ b/imblearn/under_sampling/neighbourhood_cleaning_rule.py
@@ -77,7 +77,7 @@ class NeighbourhoodCleaningRule(BaseMulticlassSampler):
     >>> ncr = NeighbourhoodCleaningRule(random_state=42)
     >>> X_res, y_res = ncr.fit_sample(X, y)
     >>> print('Resampled dataset shape {}'.format(Counter(y_res)))
-    Resampled dataset shape Counter({1: 891, 0: 100})
+    Resampled dataset shape Counter({1: 889, 0: 100})
 
     References
     ----------

--- a/imblearn/under_sampling/tests/test_neighbourhood_cleaning_rule.py
+++ b/imblearn/under_sampling/tests/test_neighbourhood_cleaning_rule.py
@@ -82,10 +82,10 @@ def test_ncr_fit_sample():
     X_resampled, y_resampled = ncr.fit_sample(X, Y)
 
     X_gt = np.array([[-1.20809175, -1.49917302], [-0.60497017, -0.66630228],
-                     [-0.91735824, 0.93110278], [-0.20413357, 0.64628718],
+                     [-0.91735824, 0.93110278],
                      [0.35967591, 2.61186964], [-1.55581933, 1.09609604],
                      [1.55157493, -1.6981518]])
-    y_gt = np.array([0, 0, 1, 1, 2, 1, 2])
+    y_gt = np.array([0, 0, 1, 2, 1, 2])
     assert_array_equal(X_resampled, X_gt)
     assert_array_equal(y_resampled, y_gt)
 
@@ -98,11 +98,11 @@ def test_ncr_fit_sample_with_indices():
     X_resampled, y_resampled, idx_under = ncr.fit_sample(X, Y)
 
     X_gt = np.array([[-1.20809175, -1.49917302], [-0.60497017, -0.66630228],
-                     [-0.91735824, 0.93110278], [-0.20413357, 0.64628718],
+                     [-0.91735824, 0.93110278],
                      [0.35967591, 2.61186964], [-1.55581933, 1.09609604],
                      [1.55157493, -1.6981518]])
-    y_gt = np.array([0, 0, 1, 1, 2, 1, 2])
-    idx_gt = np.array([10, 11, 3, 5, 7, 13, 14])
+    y_gt = np.array([0, 0, 1, 2, 1, 2])
+    idx_gt = np.array([10, 11, 3, 7, 13, 14])
     assert_array_equal(X_resampled, X_gt)
     assert_array_equal(y_resampled, y_gt)
     assert_array_equal(idx_under, idx_gt)
@@ -139,11 +139,11 @@ def test_ncr_fit_sample_nn_obj():
     X_resampled, y_resampled, idx_under = ncr.fit_sample(X, Y)
 
     X_gt = np.array([[-1.20809175, -1.49917302], [-0.60497017, -0.66630228],
-                     [-0.91735824, 0.93110278], [-0.20413357, 0.64628718],
+                     [-0.91735824, 0.93110278],
                      [0.35967591, 2.61186964], [-1.55581933, 1.09609604],
                      [1.55157493, -1.6981518]])
-    y_gt = np.array([0, 0, 1, 1, 2, 1, 2])
-    idx_gt = np.array([10, 11, 3, 5, 7, 13, 14])
+    y_gt = np.array([0, 0, 1, 2, 1, 2])
+    idx_gt = np.array([10, 11, 3, 7, 13, 14])
     assert_array_equal(X_resampled, X_gt)
     assert_array_equal(y_resampled, y_gt)
     assert_array_equal(idx_under, idx_gt)


### PR DESCRIPTION
Fixed: for misclassified positive samples they are returned themselves but not their negative neighbours (so behaviour for positive result of IF statement is wrong). #227 