### PR TITLE
Allow None objects in Pipeline chain

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -21,7 +21,7 @@ Bug fixes
 - Fixed a bug in :class:`under_sampling.AllKNN`, add stopping criteria to avoid that the minority class become a majority class or that a class disappear. By `Guillaume Lemaitre`_.
 - Fixed a bug in :class:`under_sampling.CondensedNeareastNeigbour`, correction of the list of indices returned. By `Guillaume Lemaitre`_.
 - Fixed a bug in :class:`ensemble.BalanceCascade`, solve the issue to obtain a single array if desired. By `Guillaume Lemaitre`_.
-- Fixed a bug in :class:`pipeline.Pipeline`, solve to embed `Pipeline` in other `Pipeline. By `Christos Aridas`_ .
+- Fixed a bug in :class:`pipeline.Pipeline`, solve to embed `Pipeline` in other `Pipeline`. By `Christos Aridas`_ .
 - Fixed a bug in :class:`pipeline.Pipeline`, solve the issue to put to sampler in the same `Pipeline`. By `Christos Aridas`_ .
 - Fixed a bug in :class:`under_sampling.CondensedNeareastNeigbour`, correction of the shape of `sel_x` when only one sample is selected. By `Aliaksei Halachkin`_.
 - Fixed a bug in :class:`under_sampling.NeighbourhoodCleaningRule`, selecting neighbours instead of minority class misclassified samples. By `Aleksandr Loskutov`_.
@@ -32,6 +32,7 @@ New features
 
 - Added AllKNN under sampling technique. By `Dayvid Oliveira`_.
 - Added a module `metrics` implementing some specific scoring function for the problem of balancing. By `Guillaume Lemaitre`_ and `Christos Aridas`_.
+- Turn off steps in :class:`pipeline.Pipeline` using the `None` object. By `Christos Aridas`_.
 
 Enhancement
 ~~~~~~~~~~~

--- a/imblearn/pipeline.py
+++ b/imblearn/pipeline.py
@@ -125,6 +125,8 @@ class Pipeline(pipeline.Pipeline):
         estimator = estimators[-1]
 
         for t in transforms:
+            if t is None:
+                continue
             _validate_step_methods(t)
             _validate_step_behaviour(t)
             _validate_step_class(t)
@@ -144,6 +146,8 @@ class Pipeline(pipeline.Pipeline):
         Xt = X
         yt = y
         for name, transform in self.steps[:-1]:
+            if transform is None:
+                continue
             if hasattr(transform, "fit_transform"):
                 Xt = transform.fit_transform(Xt, yt, **fit_params_steps[name])
             elif hasattr(transform, "fit_sample"):
@@ -224,6 +228,8 @@ class Pipeline(pipeline.Pipeline):
         """
         Xt = X
         for _, transform in self.steps[:-1]:
+            if transform is None:
+                continue
             if hasattr(transform, "fit_sample"):
                 # XXX: Calling sample in pipeline it means that the
                 # last estimator is a sampler. Samplers don't carry
@@ -248,6 +254,8 @@ class Pipeline(pipeline.Pipeline):
         """
         Xt = X
         for _, transform in self.steps[:-1]:
+            if transform is None:
+                continue
             if hasattr(transform, "fit_sample"):
                 pass
             else:
@@ -289,6 +297,8 @@ class Pipeline(pipeline.Pipeline):
         """
         Xt = X
         for _, transform in self.steps[:-1]:
+            if transform is None:
+                continue
             if hasattr(transform, "fit_sample"):
                 pass
             else:
@@ -309,6 +319,8 @@ class Pipeline(pipeline.Pipeline):
         """
         Xt = X
         for _, transform in self.steps[:-1]:
+            if transform is None:
+                continue
             if hasattr(transform, "fit_sample"):
                 pass
             else:
@@ -329,6 +341,8 @@ class Pipeline(pipeline.Pipeline):
         """
         Xt = X
         for _, transform in self.steps[:-1]:
+            if transform is None:
+                continue
             if hasattr(transform, "fit_sample"):
                 pass
             else:
@@ -349,6 +363,8 @@ class Pipeline(pipeline.Pipeline):
         """
         Xt = X
         for _, transform in self.steps:
+            if transform is None:
+                continue
             if hasattr(transform, "fit_sample"):
                 pass
             else:
@@ -374,6 +390,8 @@ class Pipeline(pipeline.Pipeline):
             X = X[None, :]
         Xt = X
         for _, step in self.steps[::-1]:
+            if step is None:
+                continue
             if hasattr(step, "fit_sample"):
                 pass
             else:
@@ -398,6 +416,8 @@ class Pipeline(pipeline.Pipeline):
         """
         Xt = X
         for _, transform in self.steps[:-1]:
+            if transform is None:
+                continue
             if hasattr(transform, "fit_sample"):
                 pass
             else:

--- a/imblearn/tests/test_pipeline.py
+++ b/imblearn/tests/test_pipeline.py
@@ -2,6 +2,7 @@
 Test the pipeline module.
 """
 import numpy as np
+from numpy.testing import assert_array_almost_equal
 from sklearn.base import clone
 from sklearn.cluster import KMeans
 from sklearn.datasets import load_iris, make_classification
@@ -39,6 +40,7 @@ class IncorrectT(object):
 
 
 class T(IncorrectT):
+
     def fit(self, X, y):
         return self
 
@@ -51,6 +53,7 @@ class T(IncorrectT):
 
 
 class TransfT(T):
+
     def transform(self, X, y=None):
         return X
 
@@ -461,6 +464,117 @@ def test_pipeline_sample_transform():
     pipeline = Pipeline([('pca', pca), ('rus', rus), ('pca2', pca2)])
 
     pipeline.fit(X, y).transform(X)
+
+
+def test_pipeline_none_classifier():
+    # Test pipeline using None as preprocessing step and a classifier
+    X, y = make_classification(
+        n_classes=2,
+        class_sep=2,
+        weights=[0.1, 0.9],
+        n_informative=3,
+        n_redundant=1,
+        flip_y=0,
+        n_features=20,
+        n_clusters_per_class=1,
+        n_samples=5000,
+        random_state=0)
+    clf = LogisticRegression(random_state=0)
+    pipe = make_pipeline(None, clf)
+    pipe.fit(X, y)
+    pipe.predict(X)
+    pipe.predict_proba(X)
+    pipe.decision_function(X)
+    pipe.score(X, y)
+
+
+def test_pipeline_none_sampler_classifier():
+    # Test pipeline using None, RUS and a classifier
+    X, y = make_classification(
+        n_classes=2,
+        class_sep=2,
+        weights=[0.1, 0.9],
+        n_informative=3,
+        n_redundant=1,
+        flip_y=0,
+        n_features=20,
+        n_clusters_per_class=1,
+        n_samples=5000,
+        random_state=0)
+    clf = LogisticRegression(random_state=0)
+    rus = RandomUnderSampler(random_state=0)
+    pipe = make_pipeline(None, rus, clf)
+    pipe.fit(X, y)
+    pipe.predict(X)
+    pipe.predict_proba(X)
+    pipe.decision_function(X)
+    pipe.score(X, y)
+
+
+def test_pipeline_sampler_none_classifier():
+    # Test pipeline using RUS, None and a classifier
+    X, y = make_classification(
+        n_classes=2,
+        class_sep=2,
+        weights=[0.1, 0.9],
+        n_informative=3,
+        n_redundant=1,
+        flip_y=0,
+        n_features=20,
+        n_clusters_per_class=1,
+        n_samples=5000,
+        random_state=0)
+    clf = LogisticRegression(random_state=0)
+    rus = RandomUnderSampler(random_state=0)
+    pipe = make_pipeline(rus, None, clf)
+    pipe.fit(X, y)
+    pipe.predict(X)
+    pipe.predict_proba(X)
+    pipe.decision_function(X)
+    pipe.score(X, y)
+
+
+def test_pipeline_none_sampler_sample():
+    # Test pipeline using None step and a sampler
+    X, y = make_classification(
+        n_classes=2,
+        class_sep=2,
+        weights=[0.1, 0.9],
+        n_informative=3,
+        n_redundant=1,
+        flip_y=0,
+        n_features=20,
+        n_clusters_per_class=1,
+        n_samples=5000,
+        random_state=0)
+
+    rus = RandomUnderSampler(random_state=0)
+    pipe = make_pipeline(None, rus)
+    pipe.fit(X, y)
+    pipe.sample(X, y)
+
+
+def test_pipeline_none_transformer():
+    # Test pipeline using None and a transformer that implements transform and
+    # inverse_transform
+    X, y = make_classification(
+        n_classes=2,
+        class_sep=2,
+        weights=[0.1, 0.9],
+        n_informative=3,
+        n_redundant=1,
+        flip_y=0,
+        n_features=20,
+        n_clusters_per_class=1,
+        n_samples=5000,
+        random_state=0)
+
+    pca = PCA(whiten=True)
+    pipe = make_pipeline(None, pca)
+    pipe.fit(X, y)
+    X_trans = pipe.transform(X)
+    X_inversed = pipe.inverse_transform(X_trans)
+    assert_array_almost_equal(X, X_inversed)
 
 
 def test_pipeline_methods_anova_rus():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #226 

#### What does this implement/fix? Explain your changes.
`Pipeline` should allow `None` objects in prepossessing steps. With this modification 
one could use `*SearchCV` estimators and examine if the performance of the final 
classifier is improved by using a sampler or not.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
