### PR TITLE
[MRG] Correcting EasyEnsemble doc

### DIFF
--- a/imblearn/ensemble/easy_ensemble.py
+++ b/imblearn/ensemble/easy_ensemble.py
@@ -24,7 +24,7 @@ class EasyEnsemble(BaseMulticlassSampler):
         of samples in the minority class over the the number of samples
         in the majority class.
 
-    return_indices : bool, optional (default=True)
+    return_indices : bool, optional (default=False)
         Whether or not to return the indices of the samples randomly
         selected from the majority class.
 


### PR DESCRIPTION
In EasyEnsemble doc page, its signature is

> class imblearn.ensemble.EasyEnsemble(ratio='auto', return_indices=False, random_state=None, replacement=False, n_subsets=10)

with `return_indices=False`, but its pydoc says

> return_indices : bool, optional (default=True)
>
>Whether or not to return the indices of the samples randomly selected from the majority class.

Checking the code at https://github.com/scikit-learn-contrib/imbalanced-learn/blob/b45a3e4167d188ec9fd40afd3a56330aa80a5ee1/imblearn/ensemble/easy_ensemble.py#L92, the correct value is False.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
