### PR TITLE
DOC: Style the links so they stand out only in examples

### DIFF
--- a/doc/_static/css/imbalanced-learn.css
+++ b/doc/_static/css/imbalanced-learn.css
@@ -1,5 +1,5 @@
 @import url("theme.css");
 
-a {
+.highlight a {
     text-decoration: underline;
 }


### PR DESCRIPTION
The #262 made the links to be underlined everywhere. With this fix only the reference links are underlined and only in the code section of examples

# Before
![image](https://cloud.githubusercontent.com/assets/11897937/24293153/114a2eca-1099-11e7-8057-91fca4e67068.png)

# After
![image](https://cloud.githubusercontent.com/assets/11897937/24293172/246b7c84-1099-11e7-8e82-b2b7bf3ceed0.png)
