### PR TITLE
[MRG] FIX/TST pass argument to ratio as callable

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -16,6 +16,8 @@ Bug fixes
   indices returned were wrong. By `Guillaume Lemaitre`_.
 - fixed bug for :class:`ensemble.BalanceCascade` and :class:`combine.SMOTEENN`
   and :class:`SMOTETomek. By `Guillaume Lemaitre`_.`
+- Fixed bug for `check_ratio` to be able to pass arguments when `ratio` is a
+  callable. By `Guillaume Lemaitre`_.`
 
 New features
 ~~~~~~~~~~~~

--- a/imblearn/utils/tests/test_validation.py
+++ b/imblearn/utils/tests/test_validation.py
@@ -170,3 +170,18 @@ def test_ratio_callable():
 
     ratio_ = check_ratio(ratio_func, y, 'over-sampling')
     assert_equal(ratio_, {1: 50, 2: 0, 3: 75})
+
+
+def test_ratio_callable_args():
+    y = np.array([1] * 50 + [2] * 100 + [3] * 25)
+    multiplier = {1: 1.5, 2: 1, 3: 3}
+
+    def ratio_func(y, multiplier):
+        """samples such that each class will be affected by the multiplier."""
+        target_stats = Counter(y)
+        return {key: int(values * multiplier[key])
+                for key, values in target_stats.items()}
+
+    ratio_ = check_ratio(ratio_func, y, 'over-sampling',
+                         kw_args={'multiplier': multiplier})
+    assert_equal(ratio_, {1: 25, 2: 0, 3: 50})

--- a/imblearn/utils/tests/test_validation.py
+++ b/imblearn/utils/tests/test_validation.py
@@ -183,5 +183,5 @@ def test_ratio_callable_args():
                 for key, values in target_stats.items()}
 
     ratio_ = check_ratio(ratio_func, y, 'over-sampling',
-                         kw_args={'multiplier': multiplier})
+                         multiplier=multiplier)
     assert_equal(ratio_, {1: 25, 2: 0, 3: 50})

--- a/imblearn/utils/validation.py
+++ b/imblearn/utils/validation.py
@@ -252,7 +252,7 @@ def _ratio_float(ratio, y, sampling_type):
     return ratio
 
 
-def check_ratio(ratio, y, sampling_type):
+def check_ratio(ratio, y, sampling_type, kw_args=None):
     """Ratio validation for samplers.
 
     Checks ratio for consistent type and return a dictionary
@@ -284,6 +284,9 @@ def check_ratio(ratio, y, sampling_type):
     sampling_type : str,
         The type of sampling. Can be either ``'over-sampling'`` or
         ``'under-sampling'``.
+
+    kw_args : dict, optional
+        Dictionary of additional keyword arguments to pass to ratio.
 
     Returns
     -------
@@ -318,7 +321,7 @@ def check_ratio(ratio, y, sampling_type):
                              " (0, 1]. Got {} instead.".format(ratio))
         return _ratio_float(ratio, y, sampling_type)
     elif callable(ratio):
-        ratio_ = ratio(y)
+        ratio_ = ratio(y, **(kw_args if kw_args else {}))
         return _ratio_dict(ratio_, y, sampling_type)
 
 

--- a/imblearn/utils/validation.py
+++ b/imblearn/utils/validation.py
@@ -252,7 +252,7 @@ def _ratio_float(ratio, y, sampling_type):
     return ratio
 
 
-def check_ratio(ratio, y, sampling_type, kw_args=None):
+def check_ratio(ratio, y, sampling_type, **kwargs):
     """Ratio validation for samplers.
 
     Checks ratio for consistent type and return a dictionary
@@ -285,8 +285,8 @@ def check_ratio(ratio, y, sampling_type, kw_args=None):
         The type of sampling. Can be either ``'over-sampling'`` or
         ``'under-sampling'``.
 
-    kw_args : dict, optional
-        Dictionary of additional keyword arguments to pass to ratio.
+    kwargs : dict, optional
+        Dictionary of additional keyword arguments to pass to ``ratio``.
 
     Returns
     -------
@@ -321,7 +321,7 @@ def check_ratio(ratio, y, sampling_type, kw_args=None):
                              " (0, 1]. Got {} instead.".format(ratio))
         return _ratio_float(ratio, y, sampling_type)
     elif callable(ratio):
-        ratio_ = ratio(y, **(kw_args if kw_args else {}))
+        ratio_ = ratio(y, **kwargs)
         return _ratio_dict(ratio_, y, sampling_type)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
closes #305 

#### What does this implement/fix? Explain your changes.
Allow to pass argument to ratio when this is a function.
It could be useful when the heuristic is outside of the function

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
