### PR TITLE
[MRG] MAINT make hash deterministic

### DIFF
--- a/doc/under_sampling.rst
+++ b/doc/under_sampling.rst
@@ -112,7 +112,7 @@ samples. :class:`NearMiss` implements 3 different types of heuristic which can
 be selected with the parameter ``version``::
 
   >>> from imblearn.under_sampling import NearMiss
-  >>> nm1 = NearMiss(random_state=0, version=1)
+  >>> nm1 = NearMiss(version=1)
   >>> X_resampled_nm1, y_resampled = nm1.fit_sample(X, y)
   >>> print(sorted(Counter(y_resampled).items()))
   [(0, 64), (1, 64), (2, 64)]
@@ -247,7 +247,7 @@ the sample inspected to keep it in the dataset::
   >>> sorted(Counter(y).items())
   [(0, 64), (1, 262), (2, 4674)]
   >>> from imblearn.under_sampling import EditedNearestNeighbours
-  >>> enn = EditedNearestNeighbours(random_state=0)
+  >>> enn = EditedNearestNeighbours()
   >>> X_resampled, y_resampled = enn.fit_sample(X, y)
   >>> print(sorted(Counter(y_resampled).items()))
   [(0, 64), (1, 213), (2, 4568)]
@@ -261,7 +261,7 @@ the decision to keep a given sample or not.
 Generally, repeating the algorithm will delete more data::
 
    >>> from imblearn.under_sampling import RepeatedEditedNearestNeighbours
-   >>> renn = RepeatedEditedNearestNeighbours(random_state=0)
+   >>> renn = RepeatedEditedNearestNeighbours()
    >>> X_resampled, y_resampled = renn.fit_sample(X, y)
    >>> print(sorted(Counter(y_resampled).items()))
    [(0, 64), (1, 208), (2, 4551)]
@@ -271,7 +271,7 @@ Generally, repeating the algorithm will delete more data::
 internal nearest neighbors algorithm is increased at each iteration::
 
   >>> from imblearn.under_sampling import AllKNN
-  >>> allknn = AllKNN(random_state=0)
+  >>> allknn = AllKNN()
   >>> X_resampled, y_resampled = allknn.fit_sample(X, y)
   >>> print(sorted(Counter(y_resampled).items()))
   [(0, 64), (1, 220), (2, 4601)]
@@ -338,7 +338,7 @@ between the :class:`EditedNearestNeighbours` and the output a 3 nearest
 neighbors classifier. The class can be used as::
 
   >>> from imblearn.under_sampling import NeighbourhoodCleaningRule
-  >>> ncr = NeighbourhoodCleaningRule(random_state=0)
+  >>> ncr = NeighbourhoodCleaningRule()
   >>> X_resampled, y_resampled = ncr.fit_sample(X, y)
   >>> print(sorted(Counter(y_resampled).items()))
   [(0, 64), (1, 234), (2, 4666)]

--- a/examples/under-sampling/plot_illustration_tomek_links.py
+++ b/examples/under-sampling/plot_illustration_tomek_links.py
@@ -67,7 +67,7 @@ fig.tight_layout()
 # samples. If ``ratio='auto'`` only the sample from the majority class will be
 # removed. If ``ratio='all'`` both samples will be removed.
 
-sampler = TomekLinks(random_state=0)
+sampler = TomekLinks()
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 6))
 

--- a/imblearn/base.py
+++ b/imblearn/base.py
@@ -131,9 +131,8 @@ class BaseSampler(SamplerMixin):
     instead.
     """
 
-    def __init__(self, ratio='auto', random_state=None):
+    def __init__(self, ratio='auto'):
         self.ratio = ratio
-        self.random_state = random_state
         self.logger = logging.getLogger(__name__)
 
     def fit(self, X, y):

--- a/imblearn/combine/smote_enn.py
+++ b/imblearn/combine/smote_enn.py
@@ -125,8 +125,7 @@ class SMOTEENN(SamplerMixin):
                                  ' Got {} instead.'.format(type(self.enn)))
         # Otherwise create a default EditedNearestNeighbours
         else:
-            self.enn_ = EditedNearestNeighbours(ratio='all',
-                                                random_state=self.random_state)
+            self.enn_ = EditedNearestNeighbours(ratio='all')
 
     def fit(self, X, y):
         """Find the classes statistics before to perform sampling.

--- a/imblearn/combine/smote_tomek.py
+++ b/imblearn/combine/smote_tomek.py
@@ -134,8 +134,7 @@ SMOTETomek # doctest: +NORMALIZE_WHITESPACE
                                  'Got {} instead.'.format(type(self.tomek)))
         # Otherwise create a default TomekLinks
         else:
-            self.tomek_ = TomekLinks(ratio='all',
-                                     random_state=self.random_state)
+            self.tomek_ = TomekLinks(ratio='all')
 
     def fit(self, X, y):
         """Find the classes statistics before to perform sampling.

--- a/imblearn/ensemble/balance_cascade.py
+++ b/imblearn/ensemble/balance_cascade.py
@@ -113,8 +113,8 @@ BalanceCascade # doctest: +NORMALIZE_WHITESPACE
                  random_state=None,
                  n_max_subset=None,
                  estimator=None):
-        super(BalanceCascade, self).__init__(ratio=ratio,
-                                             random_state=random_state)
+        super(BalanceCascade, self).__init__(ratio=ratio)
+        self.random_state = random_state
         self.return_indices = return_indices
         self.estimator = estimator
         self.n_max_subset = n_max_subset

--- a/imblearn/ensemble/easy_ensemble.py
+++ b/imblearn/ensemble/easy_ensemble.py
@@ -101,8 +101,8 @@ EasyEnsemble # doctest: +NORMALIZE_WHITESPACE
                  random_state=None,
                  replacement=False,
                  n_subsets=10):
-        super(EasyEnsemble, self).__init__(ratio=ratio,
-                                           random_state=random_state)
+        super(EasyEnsemble, self).__init__(ratio=ratio)
+        self.random_state = random_state
         self.return_indices = return_indices
         self.replacement = replacement
         self.n_subsets = n_subsets

--- a/imblearn/over_sampling/adasyn.py
+++ b/imblearn/over_sampling/adasyn.py
@@ -104,7 +104,8 @@ ADASYN # doctest: +NORMALIZE_WHITESPACE
                  random_state=None,
                  n_neighbors=5,
                  n_jobs=1):
-        super(ADASYN, self).__init__(ratio=ratio, random_state=random_state)
+        super(ADASYN, self).__init__(ratio=ratio)
+        self.random_state = random_state
         self.n_neighbors = n_neighbors
         self.n_jobs = n_jobs
 

--- a/imblearn/over_sampling/base.py
+++ b/imblearn/over_sampling/base.py
@@ -5,8 +5,6 @@ Base class for the over-sampling method.
 #          Christos Aridas
 # License: MIT
 
-from sklearn.utils import check_X_y
-
 from ..base import BaseSampler
 
 

--- a/imblearn/over_sampling/random_over_sampler.py
+++ b/imblearn/over_sampling/random_over_sampler.py
@@ -76,8 +76,8 @@ RandomOverSampler # doctest: +NORMALIZE_WHITESPACE
     """
 
     def __init__(self, ratio='auto', random_state=None):
-        super(RandomOverSampler, self).__init__(
-            ratio=ratio, random_state=random_state)
+        super(RandomOverSampler, self).__init__(ratio=ratio)
+        self.random_state = random_state
 
     def _sample(self, X, y):
         """Resample the dataset.

--- a/imblearn/over_sampling/smote.py
+++ b/imblearn/over_sampling/smote.py
@@ -143,7 +143,8 @@ SMOTE # doctest: +NORMALIZE_WHITESPACE
                  kind='regular',
                  svm_estimator=None,
                  n_jobs=1):
-        super(SMOTE, self).__init__(ratio=ratio, random_state=random_state)
+        super(SMOTE, self).__init__(ratio=ratio)
+        self.random_state = random_state
         self.kind = kind
         self.k_neighbors = k_neighbors
         self.m_neighbors = m_neighbors

--- a/imblearn/under_sampling/prototype_generation/cluster_centroids.py
+++ b/imblearn/under_sampling/prototype_generation/cluster_centroids.py
@@ -109,7 +109,8 @@ ClusterCentroids # doctest: +NORMALIZE_WHITESPACE
                  voting='auto',
                  n_jobs=1):
         super(ClusterCentroids, self).__init__(
-            ratio=ratio, random_state=random_state)
+            ratio=ratio)
+        self.random_state = random_state
         self.estimator = estimator
         self.voting = voting
         self.n_jobs = n_jobs

--- a/imblearn/under_sampling/prototype_selection/condensed_nearest_neighbour.py
+++ b/imblearn/under_sampling/prototype_selection/condensed_nearest_neighbour.py
@@ -119,7 +119,8 @@ CondensedNearestNeighbour #doctest: +SKIP
                  n_seeds_S=1,
                  n_jobs=1):
         super(CondensedNearestNeighbour, self).__init__(
-            ratio=ratio, random_state=random_state)
+            ratio=ratio)
+        self.random_state = random_state
         self.return_indices = return_indices
         self.n_neighbors = n_neighbors
         self.n_seeds_S = n_seeds_S

--- a/imblearn/under_sampling/prototype_selection/edited_nearest_neighbours.py
+++ b/imblearn/under_sampling/prototype_selection/edited_nearest_neighbours.py
@@ -18,6 +18,8 @@ from sklearn.utils import safe_indexing
 
 from ..base import BaseCleaningSampler
 from ...utils import check_neighbors_object
+from ...utils.deprecation import deprecate_parameter
+
 
 SEL_KIND = ('all', 'mode')
 
@@ -61,6 +63,9 @@ class EditedNearestNeighbours(BaseCleaningSampler):
         generator; If ``RandomState`` instance, random_state is the random
         number generator; If ``None``, the random number generator is the
         ``RandomState`` instance used by ``np.random``.
+
+        .. deprecated:: 0.4
+           ``random_state`` is deprecated in 0.4 and will be removed in 0.6.
 
     n_neighbors : int or object, optional (default=3)
         If ``int``, size of the neighbourhood to consider to compute the
@@ -112,7 +117,7 @@ EditedNearestNeighbours # doctest: +NORMALIZE_WHITESPACE
     ... n_features=20, n_clusters_per_class=1, n_samples=1000, random_state=10)
     >>> print('Original dataset shape {}'.format(Counter(y)))
     Original dataset shape Counter({1: 900, 0: 100})
-    >>> enn = EditedNearestNeighbours(random_state=42)
+    >>> enn = EditedNearestNeighbours()
     >>> X_res, y_res = enn.fit_sample(X, y)
     >>> print('Resampled dataset shape {}'.format(Counter(y_res)))
     Resampled dataset shape Counter({1: 887, 0: 100})
@@ -126,9 +131,8 @@ EditedNearestNeighbours # doctest: +NORMALIZE_WHITESPACE
                  n_neighbors=3,
                  kind_sel='all',
                  n_jobs=1):
-        super(EditedNearestNeighbours, self).__init__(
-            ratio=ratio,
-            random_state=random_state)
+        super(EditedNearestNeighbours, self).__init__(ratio=ratio)
+        self.random_state = random_state
         self.return_indices = return_indices
         self.n_neighbors = n_neighbors
         self.kind_sel = kind_sel
@@ -136,6 +140,11 @@ EditedNearestNeighbours # doctest: +NORMALIZE_WHITESPACE
 
     def _validate_estimator(self):
         """Validate the estimator created in the ENN."""
+
+        # check for deprecated random_state
+        if self.random_state is not None:
+            deprecate_parameter(self, '0.4', 'random_state')
+
         self.nn_ = check_neighbors_object('n_neighbors', self.n_neighbors,
                                           additional_neighbor=1)
         self.nn_.set_params(**{'n_jobs': self.n_jobs})
@@ -243,6 +252,9 @@ class RepeatedEditedNearestNeighbours(BaseCleaningSampler):
         number generator; If ``None``, the random number generator is the
         ``RandomState`` instance used by ``np.random``.
 
+        .. deprecated:: 0.4
+           ``random_state`` is deprecated in 0.4 and will be removed in 0.6.
+
     n_neighbors : int or object, optional (default=3)
         If ``int``, size of the neighbourhood to consider to compute the
         nearest neighbors. If object, an estimator that inherits from
@@ -297,7 +309,7 @@ RepeatedEditedNearestNeighbours # doctest : +NORMALIZE_WHITESPACE
     ... n_features=20, n_clusters_per_class=1, n_samples=1000, random_state=10)
     >>> print('Original dataset shape {}'.format(Counter(y)))
     Original dataset shape Counter({1: 900, 0: 100})
-    >>> renn = RepeatedEditedNearestNeighbours(random_state=42)
+    >>> renn = RepeatedEditedNearestNeighbours()
     >>> X_res, y_res = renn.fit_sample(X, y)
     >>> print('Resampled dataset shape {}'.format(Counter(y_res)))
     Resampled dataset shape Counter({1: 887, 0: 100})
@@ -312,8 +324,8 @@ RepeatedEditedNearestNeighbours # doctest : +NORMALIZE_WHITESPACE
                  max_iter=100,
                  kind_sel='all',
                  n_jobs=1):
-        super(RepeatedEditedNearestNeighbours, self).__init__(
-            ratio=ratio, random_state=random_state)
+        super(RepeatedEditedNearestNeighbours, self).__init__(ratio=ratio)
+        self.random_state = random_state
         self.return_indices = return_indices
         self.n_neighbors = n_neighbors
         self.kind_sel = kind_sel
@@ -322,6 +334,11 @@ RepeatedEditedNearestNeighbours # doctest : +NORMALIZE_WHITESPACE
 
     def _validate_estimator(self):
         """Private function to create the NN estimator"""
+
+        # check for deprecated random_state
+        if self.random_state is not None:
+            deprecate_parameter(self, '0.4', 'random_state')
+
         if self.max_iter < 2:
             raise ValueError('max_iter must be greater than 1.'
                              ' Got {} instead.'.format(type(self.max_iter)))
@@ -331,7 +348,6 @@ RepeatedEditedNearestNeighbours # doctest : +NORMALIZE_WHITESPACE
 
         self.enn_ = EditedNearestNeighbours(ratio=self.ratio,
                                             return_indices=self.return_indices,
-                                            random_state=self.random_state,
                                             n_neighbors=self.nn_,
                                             kind_sel=self.kind_sel,
                                             n_jobs=self.n_jobs)
@@ -459,6 +475,9 @@ class AllKNN(BaseCleaningSampler):
         number generator; If ``None``, the random number generator is the
         ``RandomState`` instance used by ``np.random``.
 
+        .. deprecated:: 0.4
+           ``random_state`` is deprecated in 0.4 and will be removed in 0.6.
+
     n_neighbors : int or object, optional (default=3)
         If ``int``, size of the neighbourhood to consider to compute the
         nearest neighbors. If object, an estimator that inherits from
@@ -514,7 +533,7 @@ AllKNN # doctest: +NORMALIZE_WHITESPACE
     ... n_features=20, n_clusters_per_class=1, n_samples=1000, random_state=10)
     >>> print('Original dataset shape {}'.format(Counter(y)))
     Original dataset shape Counter({1: 900, 0: 100})
-    >>> allknn = AllKNN(random_state=42)
+    >>> allknn = AllKNN()
     >>> X_res, y_res = allknn.fit_sample(X, y)
     >>> print('Resampled dataset shape {}'.format(Counter(y_res)))
     Resampled dataset shape Counter({1: 887, 0: 100})
@@ -529,7 +548,8 @@ AllKNN # doctest: +NORMALIZE_WHITESPACE
                  kind_sel='all',
                  allow_minority=False,
                  n_jobs=1):
-        super(AllKNN, self).__init__(ratio=ratio, random_state=random_state)
+        super(AllKNN, self).__init__(ratio=ratio)
+        self.random_state = random_state
         self.return_indices = return_indices
         self.n_neighbors = n_neighbors
         self.kind_sel = kind_sel
@@ -538,6 +558,11 @@ AllKNN # doctest: +NORMALIZE_WHITESPACE
 
     def _validate_estimator(self):
         """Create objects required by AllKNN"""
+
+        # check for deprecated random_state
+        if self.random_state is not None:
+            deprecate_parameter(self, '0.4', 'random_state')
+
         if self.kind_sel not in SEL_KIND:
             raise NotImplementedError
 
@@ -546,7 +571,6 @@ AllKNN # doctest: +NORMALIZE_WHITESPACE
 
         self.enn_ = EditedNearestNeighbours(ratio=self.ratio,
                                             return_indices=self.return_indices,
-                                            random_state=self.random_state,
                                             n_neighbors=self.nn_,
                                             kind_sel=self.kind_sel,
                                             n_jobs=self.n_jobs)

--- a/imblearn/under_sampling/prototype_selection/instance_hardness_threshold.py
+++ b/imblearn/under_sampling/prototype_selection/instance_hardness_threshold.py
@@ -116,8 +116,8 @@ class InstanceHardnessThreshold(BaseCleaningSampler):
                  random_state=None,
                  cv=5,
                  n_jobs=1):
-        super(InstanceHardnessThreshold, self).__init__(
-            ratio=ratio, random_state=random_state)
+        super(InstanceHardnessThreshold, self).__init__(ratio=ratio)
+        self.random_state = random_state
         self.estimator = estimator
         self.return_indices = return_indices
         self.cv = cv
@@ -148,10 +148,6 @@ class InstanceHardnessThreshold(BaseCleaningSampler):
         y : array-like, shape (n_samples,)
             Corresponding label for each sample in X.
 
-        Returns
-        -------
-        X_resampled : {ndarray, sparse matrix}, shape \
-(n_samples_new, n_features)
             The array containing the resampled data.
 
         y_resampled : ndarray, shape (n_samples_new,)

--- a/imblearn/under_sampling/prototype_selection/nearmiss.py
+++ b/imblearn/under_sampling/prototype_selection/nearmiss.py
@@ -15,6 +15,7 @@ from sklearn.utils import safe_indexing
 
 from ..base import BaseUnderSampler
 from ...utils import check_neighbors_object
+from ...utils.deprecation import deprecate_parameter
 
 
 class NearMiss(BaseUnderSampler):
@@ -50,6 +51,9 @@ class NearMiss(BaseUnderSampler):
         generator; If ``RandomState`` instance, random_state is the random
         number generator; If ``None``, the random number generator is the
         ``RandomState`` instance used by ``np.random``.
+
+        .. deprecated:: 0.4
+           ``random_state`` is deprecated in 0.4 and will be removed in 0.6.
 
     version : int, optional (default=1)
         Version of the NearMiss to use. Possible values are 1, 2 or 3.
@@ -101,7 +105,7 @@ NearMiss # doctest: +NORMALIZE_WHITESPACE
     ... n_features=20, n_clusters_per_class=1, n_samples=1000, random_state=10)
     >>> print('Original dataset shape {}'.format(Counter(y)))
     Original dataset shape Counter({1: 900, 0: 100})
-    >>> nm = NearMiss(random_state=42)
+    >>> nm = NearMiss()
     >>> X_res, y_res = nm.fit_sample(X, y)
     >>> print('Resampled dataset shape {}'.format(Counter(y_res)))
     Resampled dataset shape Counter({0: 100, 1: 100})
@@ -116,7 +120,8 @@ NearMiss # doctest: +NORMALIZE_WHITESPACE
                  n_neighbors=3,
                  n_neighbors_ver3=3,
                  n_jobs=1):
-        super(NearMiss, self).__init__(ratio=ratio, random_state=random_state)
+        super(NearMiss, self).__init__(ratio=ratio)
+        self.random_state = random_state
         self.return_indices = return_indices
         self.version = version
         self.n_neighbors = n_neighbors
@@ -196,6 +201,11 @@ NearMiss # doctest: +NORMALIZE_WHITESPACE
 
     def _validate_estimator(self):
         """Private function to create the NN estimator"""
+
+        # check for deprecated random_state
+        if self.random_state is not None:
+            deprecate_parameter(self, '0.4', 'random_state')
+
         self.nn_ = check_neighbors_object('n_neighbors', self.n_neighbors)
         self.nn_.set_params(**{'n_jobs': self.n_jobs})
 

--- a/imblearn/under_sampling/prototype_selection/one_sided_selection.py
+++ b/imblearn/under_sampling/prototype_selection/one_sided_selection.py
@@ -110,8 +110,8 @@ KNeighborsClassifier(n_neighbors=1))
                  n_neighbors=None,
                  n_seeds_S=1,
                  n_jobs=1):
-        super(OneSidedSelection, self).__init__(ratio=ratio,
-                                                random_state=random_state)
+        super(OneSidedSelection, self).__init__(ratio=ratio)
+        self.random_state = random_state
         self.return_indices = return_indices
         self.n_neighbors = n_neighbors
         self.n_seeds_S = n_seeds_S
@@ -200,8 +200,7 @@ KNeighborsClassifier(n_neighbors=1))
         y_resampled = safe_indexing(y, idx_under)
 
         # apply Tomek cleaning
-        tl = TomekLinks(ratio=self.ratio_, return_indices=True,
-                        random_state=self.random_state)
+        tl = TomekLinks(ratio=self.ratio_, return_indices=True)
         X_cleaned, y_cleaned, idx_cleaned = tl.fit_sample(X_resampled,
                                                           y_resampled)
 

--- a/imblearn/under_sampling/prototype_selection/random_under_sampler.py
+++ b/imblearn/under_sampling/prototype_selection/random_under_sampler.py
@@ -84,8 +84,8 @@ RandomUnderSampler # doctest: +NORMALIZE_WHITESPACE
                  return_indices=False,
                  random_state=None,
                  replacement=False):
-        super(RandomUnderSampler, self).__init__(
-            ratio=ratio, random_state=random_state)
+        super(RandomUnderSampler, self).__init__(ratio=ratio)
+        self.random_state = random_state
         self.return_indices = return_indices
         self.replacement = replacement
 

--- a/imblearn/under_sampling/prototype_selection/tests/test_allknn.py
+++ b/imblearn/under_sampling/prototype_selection/tests/test_allknn.py
@@ -13,9 +13,9 @@ from sklearn.neighbors import NearestNeighbors
 from sklearn.datasets import make_classification
 
 from imblearn.under_sampling import AllKNN
+from imblearn.utils.testing import warns
 
 
-RND_SEED = 0
 X = np.array([[-0.12840393, 0.66446571], [1.32319756, -0.13181616],
               [0.04296502, -0.37981873], [0.83631853, 0.18569783],
               [1.02956816, 0.36061601], [1.12202806, 0.33811558],
@@ -44,7 +44,7 @@ R_TOL = 1e-4
 
 
 def test_allknn_fit_sample():
-    allknn = AllKNN(random_state=RND_SEED)
+    allknn = AllKNN()
     X_resampled, y_resampled = allknn.fit_sample(X, Y)
 
     X_gt = np.array([[-0.53171468, -0.53735182], [-0.88864036, -0.33782387],
@@ -75,15 +75,15 @@ def test_all_knn_allow_minority():
                                n_clusters_per_class=1, weights=[0.2, 0.3, 0.5],
                                class_sep=0.4, random_state=0)
 
-    allknn = AllKNN(random_state=RND_SEED, allow_minority=True)
+    allknn = AllKNN(allow_minority=True)
     X_res_1, y_res_1 = allknn.fit_sample(X, y)
-    allknn = AllKNN(random_state=RND_SEED)
+    allknn = AllKNN()
     X_res_2, y_res_2 = allknn.fit_sample(X, y)
     assert len(y_res_1) < len(y_res_2)
 
 
 def test_allknn_fit_sample_with_indices():
-    allknn = AllKNN(return_indices=True, random_state=RND_SEED)
+    allknn = AllKNN(return_indices=True)
     X_resampled, y_resampled, idx_under = allknn.fit_sample(X, Y)
 
     X_gt = np.array([[-0.53171468, -0.53735182], [-0.88864036, -0.33782387],
@@ -114,7 +114,7 @@ def test_allknn_fit_sample_with_indices():
 
 
 def test_allknn_fit_sample_mode():
-    allknn = AllKNN(random_state=RND_SEED, kind_sel='mode')
+    allknn = AllKNN(kind_sel='mode')
     X_resampled, y_resampled = allknn.fit_sample(X, Y)
 
     X_gt = np.array([[-0.53171468, -0.53735182], [-0.88864036, -0.33782387],
@@ -143,7 +143,7 @@ def test_allknn_fit_sample_mode():
 
 def test_allknn_fit_sample_with_nn_object():
     nn = NearestNeighbors(n_neighbors=4)
-    allknn = AllKNN(n_neighbors=nn, random_state=RND_SEED, kind_sel='mode')
+    allknn = AllKNN(n_neighbors=nn, kind_sel='mode')
     X_resampled, y_resampled = allknn.fit_sample(X, Y)
 
     X_gt = np.array([[-0.53171468, -0.53735182], [-0.88864036, -0.33782387],
@@ -172,6 +172,13 @@ def test_allknn_fit_sample_with_nn_object():
 
 def test_alknn_not_good_object():
     nn = 'rnd'
-    allknn = AllKNN(n_neighbors=nn, random_state=RND_SEED, kind_sel='mode')
+    allknn = AllKNN(n_neighbors=nn, kind_sel='mode')
     with raises(ValueError):
+        allknn.fit_sample(X, Y)
+
+
+def test_deprecation_random_state():
+    allknn = AllKNN(random_state=0)
+    with warns(DeprecationWarning,
+               match="'random_state' is deprecated from 0.4"):
         allknn.fit_sample(X, Y)

--- a/imblearn/under_sampling/prototype_selection/tests/test_edited_nearest_neighbours.py
+++ b/imblearn/under_sampling/prototype_selection/tests/test_edited_nearest_neighbours.py
@@ -13,8 +13,8 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.neighbors import NearestNeighbors
 
 from imblearn.under_sampling import EditedNearestNeighbours
+from imblearn.utils.testing import warns
 
-RND_SEED = 0
 X = np.array([[2.59928271, 0.93323465], [0.25738379, 0.95564169],
               [1.42772181, 0.526027], [1.92365863, 0.82718767],
               [-0.10903849, -0.12085181], [-0.284881, -0.62730973],
@@ -29,16 +29,15 @@ Y = np.array([1, 2, 1, 1, 0, 2, 2, 2, 2, 2, 2, 0, 1, 2, 2, 2, 2, 1, 2, 1])
 
 
 def test_enn_init():
-    enn = EditedNearestNeighbours(random_state=RND_SEED)
+    enn = EditedNearestNeighbours()
 
     assert enn.n_neighbors == 3
     assert enn.kind_sel == 'all'
     assert enn.n_jobs == 1
-    assert enn.random_state == RND_SEED
 
 
 def test_enn_fit_sample():
-    enn = EditedNearestNeighbours(random_state=RND_SEED)
+    enn = EditedNearestNeighbours()
     X_resampled, y_resampled = enn.fit_sample(X, Y)
 
     X_gt = np.array([[-0.10903849, -0.12085181], [0.01936241, 0.17799828],
@@ -51,7 +50,7 @@ def test_enn_fit_sample():
 
 
 def test_enn_fit_sample_with_indices():
-    enn = EditedNearestNeighbours(return_indices=True, random_state=RND_SEED)
+    enn = EditedNearestNeighbours(return_indices=True)
     X_resampled, y_resampled, idx_under = enn.fit_sample(X, Y)
 
     X_gt = np.array([[-0.10903849, -0.12085181], [0.01936241, 0.17799828],
@@ -66,7 +65,7 @@ def test_enn_fit_sample_with_indices():
 
 
 def test_enn_fit_sample_mode():
-    enn = EditedNearestNeighbours(random_state=RND_SEED, kind_sel='mode')
+    enn = EditedNearestNeighbours(kind_sel='mode')
     X_resampled, y_resampled = enn.fit_sample(X, Y)
 
     X_gt = np.array([[-0.10903849, -0.12085181], [0.01936241, 0.17799828],
@@ -84,7 +83,7 @@ def test_enn_fit_sample_mode():
 def test_enn_fit_sample_with_nn_object():
     nn = NearestNeighbors(n_neighbors=4)
     enn = EditedNearestNeighbours(
-        n_neighbors=nn, random_state=RND_SEED, kind_sel='mode')
+        n_neighbors=nn, kind_sel='mode')
     X_resampled, y_resampled = enn.fit_sample(X, Y)
 
     X_gt = np.array([[-0.10903849, -0.12085181], [0.01936241, 0.17799828],
@@ -102,6 +101,13 @@ def test_enn_fit_sample_with_nn_object():
 def test_enn_not_good_object():
     nn = 'rnd'
     enn = EditedNearestNeighbours(
-        n_neighbors=nn, random_state=RND_SEED, kind_sel='mode')
+        n_neighbors=nn, kind_sel='mode')
     with raises(ValueError, match="has to be one of"):
+        enn.fit_sample(X, Y)
+
+
+def test_deprecation_random_state():
+    enn = EditedNearestNeighbours(random_state=0)
+    with warns(DeprecationWarning,
+               match="'random_state' is deprecated from 0.4"):
         enn.fit_sample(X, Y)

--- a/imblearn/under_sampling/prototype_selection/tests/test_nearmiss.py
+++ b/imblearn/under_sampling/prototype_selection/tests/test_nearmiss.py
@@ -12,10 +12,9 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.neighbors import NearestNeighbors
 
 from imblearn.under_sampling import NearMiss
-
 from imblearn.utils.testing import warns
 
-RND_SEED = 0
+
 X = np.array([[1.17737838, -0.2002118],
               [0.4960075, 0.86130762],
               [-0.05903827, 0.10947647],
@@ -38,7 +37,7 @@ VERSION_NEARMISS = (1, 2, 3)
 
 def test_nearmiss_wrong_version():
     version = 1000
-    nm = NearMiss(version=version, random_state=RND_SEED)
+    nm = NearMiss(version=version)
     with raises(ValueError, match="must be 1, 2 or 3"):
         nm.fit_sample(X, Y)
 
@@ -46,7 +45,7 @@ def test_nearmiss_wrong_version():
 def test_nm_wrong_nn_obj():
     ratio = 'auto'
     nn = 'rnd'
-    nm = NearMiss(ratio=ratio, random_state=RND_SEED,
+    nm = NearMiss(ratio=ratio,
                   version=VERSION_NEARMISS,
                   return_indices=True,
                   n_neighbors=nn)
@@ -54,7 +53,7 @@ def test_nm_wrong_nn_obj():
         nm.fit_sample(X, Y)
     nn3 = 'rnd'
     nn = NearestNeighbors(n_neighbors=3)
-    nm3 = NearMiss(ratio=ratio, random_state=RND_SEED,
+    nm3 = NearMiss(ratio=ratio,
                    version=3, return_indices=True,
                    n_neighbors=nn, n_neighbors_ver3=nn3)
     with raises(ValueError, match="has to be one of"):
@@ -94,7 +93,7 @@ def test_nm_fit_sample_auto():
             np.array([0, 0, 0, 1, 1, 1, 2, 2, 2]),
             np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])]
     for version_idx, version in enumerate(VERSION_NEARMISS):
-        nm = NearMiss(ratio=ratio, random_state=RND_SEED,
+        nm = NearMiss(ratio=ratio,
                       version=version)
         X_resampled, y_resampled = nm.fit_sample(X, Y)
         assert_array_equal(X_resampled, X_gt[version_idx])
@@ -137,7 +136,7 @@ def test_nm_fit_sample_auto_indices():
               np.array([3, 10, 11, 2, 8, 5, 9, 1, 6]),
               np.array([3, 10, 11, 0, 5, 8, 14, 4, 12])]
     for version_idx, version in enumerate(VERSION_NEARMISS):
-        nm = NearMiss(ratio=ratio, random_state=RND_SEED,
+        nm = NearMiss(ratio=ratio,
                       version=version, return_indices=True)
         X_resampled, y_resampled, idx_under = nm.fit_sample(X, Y)
         assert_array_equal(X_resampled, X_gt[version_idx])
@@ -185,7 +184,7 @@ def test_nm_fit_sample_float_ratio():
             np.array([0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2])]
 
     for version_idx, version in enumerate(VERSION_NEARMISS):
-        nm = NearMiss(ratio=ratio, random_state=RND_SEED,
+        nm = NearMiss(ratio=ratio,
                       version=version)
         X_resampled, y_resampled = nm.fit_sample(X, Y)
         assert_array_equal(X_resampled, X_gt[version_idx])
@@ -226,8 +225,15 @@ def test_nm_fit_sample_nn_obj():
             np.array([0, 0, 0, 1, 1, 1, 2, 2, 2]),
             np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])]
     for version_idx, version in enumerate(VERSION_NEARMISS):
-        nm = NearMiss(ratio=ratio, random_state=RND_SEED,
+        nm = NearMiss(ratio=ratio,
                       version=version, n_neighbors=nn)
         X_resampled, y_resampled = nm.fit_sample(X, Y)
         assert_array_equal(X_resampled, X_gt[version_idx])
         assert_array_equal(y_resampled, y_gt[version_idx])
+
+
+def test_deprecation_random_state():
+    nm = NearMiss(random_state=0)
+    with warns(DeprecationWarning,
+               match="'random_state' is deprecated from 0.4"):
+        nm.fit_sample(X, Y)

--- a/imblearn/under_sampling/prototype_selection/tests/test_neighbourhood_cleaning_rule.py
+++ b/imblearn/under_sampling/prototype_selection/tests/test_neighbourhood_cleaning_rule.py
@@ -7,12 +7,11 @@ import numpy as np
 from pytest import raises
 
 from sklearn.utils.testing import assert_array_equal
-
 from sklearn.neighbors import NearestNeighbors
 
 from imblearn.under_sampling import NeighbourhoodCleaningRule
+from imblearn.utils.testing import warns
 
-RND_SEED = 0
 X = np.array([[1.57737838, 0.1997882], [0.8960075, 0.46130762],
               [0.34096173, 0.50947647], [-0.91735824, 0.93110278],
               [-0.14619583, 1.33009918], [-0.20413357, 0.64628718],
@@ -38,7 +37,7 @@ def test_ncr_error():
 
 
 def test_ncr_fit_sample():
-    ncr = NeighbourhoodCleaningRule(random_state=RND_SEED)
+    ncr = NeighbourhoodCleaningRule()
     X_resampled, y_resampled = ncr.fit_sample(X, Y)
 
     X_gt = np.array([[0.34096173, 0.50947647],
@@ -57,8 +56,7 @@ def test_ncr_fit_sample():
 
 
 def test_ncr_fit_sample_mode():
-    ncr = NeighbourhoodCleaningRule(random_state=RND_SEED,
-                                    kind_sel='mode')
+    ncr = NeighbourhoodCleaningRule(kind_sel='mode')
     X_resampled, y_resampled = ncr.fit_sample(X, Y)
 
     X_gt = np.array([[0.34096173, 0.50947647],
@@ -77,7 +75,7 @@ def test_ncr_fit_sample_mode():
 
 
 def test_ncr_fit_sample_with_indices():
-    ncr = NeighbourhoodCleaningRule(return_indices=True, random_state=RND_SEED)
+    ncr = NeighbourhoodCleaningRule(return_indices=True)
     X_resampled, y_resampled, idx_under = ncr.fit_sample(X, Y)
 
     X_gt = np.array([[0.34096173, 0.50947647],
@@ -100,7 +98,7 @@ def test_ncr_fit_sample_with_indices():
 def test_ncr_fit_sample_nn_obj():
     nn = NearestNeighbors(n_neighbors=4)
     ncr = NeighbourhoodCleaningRule(
-        return_indices=True, random_state=RND_SEED, n_neighbors=nn)
+        return_indices=True, n_neighbors=nn)
     X_resampled, y_resampled, idx_under = ncr.fit_sample(X, Y)
 
     X_gt = np.array([[0.34096173, 0.50947647],
@@ -123,6 +121,13 @@ def test_ncr_fit_sample_nn_obj():
 def test_ncr_wrong_nn_obj():
     nn = 'rnd'
     ncr = NeighbourhoodCleaningRule(
-        return_indices=True, random_state=RND_SEED, n_neighbors=nn)
+        return_indices=True, n_neighbors=nn)
     with raises(ValueError, match="has to be one of"):
+        ncr.fit_sample(X, Y)
+
+
+def test_deprecation_random_state():
+    ncr = NeighbourhoodCleaningRule(random_state=0)
+    with warns(DeprecationWarning,
+               match="'random_state' is deprecated from 0.4"):
         ncr.fit_sample(X, Y)

--- a/imblearn/under_sampling/prototype_selection/tests/test_repeated_edited_nearest_neighbours.py
+++ b/imblearn/under_sampling/prototype_selection/tests/test_repeated_edited_nearest_neighbours.py
@@ -9,13 +9,12 @@ import numpy as np
 from pytest import raises
 
 from sklearn.utils.testing import assert_array_equal
-
 from sklearn.neighbors import NearestNeighbors
 
 from imblearn.under_sampling import RepeatedEditedNearestNeighbours
+from imblearn.utils.testing import warns
 
 
-RND_SEED = 0
 X = np.array([[-0.12840393, 0.66446571], [1.32319756, -0.13181616],
               [0.04296502, -0.37981873], [0.83631853, 0.18569783],
               [1.02956816, 0.36061601], [1.12202806, 0.33811558],
@@ -43,24 +42,22 @@ Y = np.array([
 
 
 def test_renn_init():
-    renn = RepeatedEditedNearestNeighbours(random_state=RND_SEED)
+    renn = RepeatedEditedNearestNeighbours()
 
     assert renn.n_neighbors == 3
     assert renn.kind_sel == 'all'
     assert renn.n_jobs == 1
-    assert renn.random_state == RND_SEED
 
 
 def test_renn_iter_wrong():
     max_iter = -1
-    renn = RepeatedEditedNearestNeighbours(
-        max_iter=max_iter, random_state=RND_SEED)
+    renn = RepeatedEditedNearestNeighbours(max_iter=max_iter)
     with raises(ValueError):
         renn.fit_sample(X, Y)
 
 
 def test_renn_fit_sample():
-    renn = RepeatedEditedNearestNeighbours(random_state=RND_SEED)
+    renn = RepeatedEditedNearestNeighbours()
     X_resampled, y_resampled = renn.fit_sample(X, Y)
 
     X_gt = np.array([[-0.53171468, -0.53735182], [-0.88864036, -0.33782387],
@@ -85,8 +82,7 @@ def test_renn_fit_sample():
 
 
 def test_renn_fit_sample_with_indices():
-    renn = RepeatedEditedNearestNeighbours(
-        return_indices=True, random_state=RND_SEED)
+    renn = RepeatedEditedNearestNeighbours(return_indices=True)
     X_resampled, y_resampled, idx_under = renn.fit_sample(X, Y)
 
     X_gt = np.array([[-0.53171468, -0.53735182], [-0.88864036, -0.33782387],
@@ -116,8 +112,7 @@ def test_renn_fit_sample_with_indices():
 
 
 def test_renn_fit_sample_mode_object():
-    renn = RepeatedEditedNearestNeighbours(
-        random_state=RND_SEED, kind_sel='mode')
+    renn = RepeatedEditedNearestNeighbours(kind_sel='mode')
     X_resampled, y_resampled = renn.fit_sample(X, Y)
 
     X_gt = np.array([[-0.53171468, -0.53735182], [-0.88864036, -0.33782387],
@@ -147,8 +142,7 @@ def test_renn_fit_sample_mode_object():
 
 def test_renn_fit_sample_mode():
     nn = NearestNeighbors(n_neighbors=4)
-    renn = RepeatedEditedNearestNeighbours(
-        n_neighbors=nn, random_state=RND_SEED, kind_sel='mode')
+    renn = RepeatedEditedNearestNeighbours(n_neighbors=nn, kind_sel='mode')
     X_resampled, y_resampled = renn.fit_sample(X, Y)
 
     X_gt = np.array([[-0.53171468, -0.53735182], [-0.88864036, -0.33782387],
@@ -179,6 +173,13 @@ def test_renn_fit_sample_mode():
 def test_renn_not_good_object():
     nn = 'rnd'
     renn = RepeatedEditedNearestNeighbours(
-        n_neighbors=nn, random_state=RND_SEED, kind_sel='mode')
+        n_neighbors=nn, kind_sel='mode')
     with raises(ValueError):
+        renn.fit_sample(X, Y)
+
+
+def test_deprecation_random_state():
+    renn = RepeatedEditedNearestNeighbours(random_state=0)
+    with warns(DeprecationWarning,
+               match="'random_state' is deprecated from 0.4"):
         renn.fit_sample(X, Y)

--- a/imblearn/under_sampling/prototype_selection/tests/test_tomek_links.py
+++ b/imblearn/under_sampling/prototype_selection/tests/test_tomek_links.py
@@ -9,8 +9,9 @@ import numpy as np
 from sklearn.utils.testing import assert_array_equal
 
 from imblearn.under_sampling import TomekLinks
+from imblearn.utils.testing import warns
 
-RND_SEED = 0
+
 X = np.array([[0.31230513, 0.1216318], [0.68481731, 0.51935141],
               [1.34192108, -0.13367336], [0.62366841, -0.21312976],
               [1.61091956, -0.40283504], [-0.37162401, -2.19400981],
@@ -25,14 +26,12 @@ Y = np.array([1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 0, 1, 0])
 
 
 def test_tl_init():
-    tl = TomekLinks(random_state=RND_SEED)
-
+    tl = TomekLinks()
     assert tl.n_jobs == 1
-    assert tl.random_state == RND_SEED
 
 
 def test_tl_fit_sample():
-    tl = TomekLinks(random_state=RND_SEED)
+    tl = TomekLinks()
     X_resampled, y_resampled = tl.fit_sample(X, Y)
 
     X_gt = np.array([[0.31230513, 0.1216318], [0.68481731, 0.51935141],
@@ -50,7 +49,7 @@ def test_tl_fit_sample():
 
 
 def test_tl_fit_sample_with_indices():
-    tl = TomekLinks(return_indices=True, random_state=RND_SEED)
+    tl = TomekLinks(return_indices=True)
     X_resampled, y_resampled, idx_under = tl.fit_sample(X, Y)
 
     X_gt = np.array([[0.31230513, 0.1216318], [0.68481731, 0.51935141],
@@ -68,3 +67,10 @@ def test_tl_fit_sample_with_indices():
     assert_array_equal(X_resampled, X_gt)
     assert_array_equal(y_resampled, y_gt)
     assert_array_equal(idx_under, idx_gt)
+
+
+def test_deprecation_random_state():
+    tl = TomekLinks(random_state=0)
+    with warns(DeprecationWarning,
+               match="'random_state' is deprecated from 0.4"):
+        tl.fit_sample(X, Y)

--- a/imblearn/under_sampling/prototype_selection/tomek_links.py
+++ b/imblearn/under_sampling/prototype_selection/tomek_links.py
@@ -12,6 +12,7 @@ from sklearn.neighbors import NearestNeighbors
 from sklearn.utils import safe_indexing
 
 from ..base import BaseCleaningSampler
+from ...utils.deprecation import deprecate_parameter
 
 
 class TomekLinks(BaseCleaningSampler):
@@ -53,6 +54,9 @@ class TomekLinks(BaseCleaningSampler):
         number generator; If ``None``, the random number generator is the
         ``RandomState`` instance used by ``np.random``.
 
+        .. deprecated:: 0.4
+           ``random_state`` is deprecated in 0.4 and will be removed in 0.6.
+
     n_jobs : int, optional (default=1)
         The number of threads to open if possible.
 
@@ -83,7 +87,7 @@ TomekLinks # doctest: +NORMALIZE_WHITESPACE
     ... n_features=20, n_clusters_per_class=1, n_samples=1000, random_state=10)
     >>> print('Original dataset shape {}'.format(Counter(y)))
     Original dataset shape Counter({1: 900, 0: 100})
-    >>> tl = TomekLinks(random_state=42)
+    >>> tl = TomekLinks()
     >>> X_res, y_res = tl.fit_sample(X, y)
     >>> print('Resampled dataset shape {}'.format(Counter(y_res)))
     Resampled dataset shape Counter({1: 897, 0: 100})
@@ -92,8 +96,8 @@ TomekLinks # doctest: +NORMALIZE_WHITESPACE
 
     def __init__(self, ratio='auto', return_indices=False,
                  random_state=None, n_jobs=1):
-        super(TomekLinks, self).__init__(ratio=ratio,
-                                         random_state=random_state)
+        super(TomekLinks, self).__init__(ratio=ratio)
+        self.random_state = random_state
         self.return_indices = return_indices
         self.n_jobs = n_jobs
 
@@ -164,6 +168,9 @@ TomekLinks # doctest: +NORMALIZE_WHITESPACE
             containing the which samples have been selected.
 
         """
+        # check for deprecated random_state
+        if self.random_state is not None:
+            deprecate_parameter(self, '0.4', 'random_state')
 
         # Find the nearest neighbour of every point
         nn = NearestNeighbors(n_neighbors=2, n_jobs=self.n_jobs)

--- a/imblearn/utils/deprecation.py
+++ b/imblearn/utils/deprecation.py
@@ -32,20 +32,26 @@ def deprecate_parameter(sampler, version_deprecation, param_deprecated,
 
     """
     warnings.simplefilter("always", DeprecationWarning)
+    x, y = version_deprecation.split('.')
+    version_removed = x + '.' + str(int(y) + 2)
     if new_param is None:
         if getattr(sampler, param_deprecated) is not None:
-            warnings.warn("'{}' is deprecated from {} and will be removed in"
-                          " {}.".format(param_deprecated,
+            warnings.warn("In the estimator {}, the parameter '{}' is"
+                          " deprecated from {} and will be removed in"
+                          " {}.".format(sampler.__class__,
+                                        param_deprecated,
                                         version_deprecation,
-                                        str(float(version_deprecation) + 0.2)),
+                                        version_removed),
                           category=DeprecationWarning)
     else:
         if getattr(sampler, param_deprecated) is not None:
-            warnings.warn("'{}' is deprecated from {} and will be removed in"
+            warnings.warn("In the estimator {}, the parameter '{}' is"
+                          "deprecated from {} and will be removed in"
                           " {}. Use '{}' instead.".format(
+                              sampler.__class__,
                               param_deprecated,
                               version_deprecation,
-                              str(float(version_deprecation) + 0.2),
+                              version_removed,
                               new_param),
                           category=DeprecationWarning)
             setattr(sampler, new_param, getattr(sampler, param_deprecated))

--- a/imblearn/utils/estimator_checks.py
+++ b/imblearn/utils/estimator_checks.py
@@ -24,6 +24,7 @@ from sklearn.utils.estimator_checks import check_estimator \
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.testing import assert_allclose
 from sklearn.utils.testing import set_random_state
+from sklearn.externals.funcsigs import signature
 
 from imblearn.base import SamplerMixin
 from imblearn.over_sampling.base import BaseOverSampler
@@ -133,7 +134,7 @@ def check_samplers_fit(name, Sampler):
 
 
 def check_samplers_fit_sample(name, Sampler):
-    sampler = Sampler(random_state=0)
+    sampler = Sampler()
     X, y = make_classification(n_samples=1000, n_classes=3,
                                n_informative=4, weights=[0.2, 0.3, 0.5],
                                random_state=0)
@@ -164,7 +165,7 @@ def check_samplers_ratio_fit_sample(name, Sampler):
     X, y = make_classification(n_samples=1000, n_classes=3,
                                n_informative=4, weights=[0.2, 0.3, 0.5],
                                random_state=0)
-    sampler = Sampler(random_state=0)
+    sampler = Sampler()
     expected_stat = Counter(y)[1]
     if isinstance(sampler, BaseOverSampler):
         ratio = {2: 498, 0: 498}
@@ -201,7 +202,7 @@ def check_samplers_sparse(name, Sampler):
                     for kind in ('regular', 'borderline1',
                                  'borderline2', 'svm')]
     elif isinstance(Sampler(), NearMiss):
-        samplers = [Sampler(random_state=0, version=version)
+        samplers = [Sampler(version=version)
                     for version in (1, 2, 3)]
     elif isinstance(Sampler(), ClusterCentroids):
         # set KMeans to full since it support sparse and dense
@@ -210,7 +211,11 @@ def check_samplers_sparse(name, Sampler):
                             estimator=KMeans(random_state=1,
                                              algorithm='full'))]
     else:
-        samplers = [Sampler(random_state=0)]
+        sampler_attr = signature(Sampler.__init__).parameters.keys()
+        if 'random_state' in sampler_attr:
+            samplers = [Sampler(random_state=0)]
+        else:
+            samplers = [Sampler()]
     for sampler in samplers:
         X_res_sparse, y_res_sparse = sampler.fit_sample(X_sparse, y)
         X_res, y_res = sampler.fit_sample(X, y)
@@ -233,16 +238,20 @@ def check_samplers_pandas(name, Sampler):
                                n_informative=4, weights=[0.2, 0.3, 0.5],
                                random_state=0)
     X_pd, y_pd = pd.DataFrame(X), pd.Series(y)
-    sampler = Sampler(random_state=0)
+    sampler = Sampler()
     if isinstance(Sampler(), SMOTE):
         samplers = [Sampler(random_state=0, kind=kind)
                     for kind in ('regular', 'borderline1',
                                  'borderline2', 'svm')]
     elif isinstance(Sampler(), NearMiss):
-            samplers = [Sampler(random_state=0, version=version)
+            samplers = [Sampler(version=version)
                         for version in (1, 2, 3)]
     else:
-        samplers = [Sampler(random_state=0)]
+        sampler_attr = signature(Sampler.__init__).parameters.keys()
+        if 'random_state' in sampler_attr:
+            samplers = [Sampler(random_state=0)]
+        else:
+            samplers = [Sampler()]
     for sampler in samplers:
         X_res_pd, y_res_pd = sampler.fit_sample(X_pd, y_pd)
         X_res, y_res = sampler.fit_sample(X, y)

--- a/imblearn/utils/tests/test_validation.py
+++ b/imblearn/utils/tests/test_validation.py
@@ -5,16 +5,18 @@
 
 from collections import Counter
 
-from pytest import raises
 import numpy as np
+from pytest import raises
 
 from sklearn.neighbors.base import KNeighborsMixin
 from sklearn.neighbors import NearestNeighbors
+from sklearn.utils import check_random_state
+from sklearn.externals import joblib
 
 from imblearn.utils.testing import warns
-
 from imblearn.utils import check_neighbors_object
 from imblearn.utils import check_ratio
+from imblearn.utils import hash_X_y
 
 
 def test_check_neighbors_object():
@@ -167,3 +169,16 @@ def test_ratio_callable_args():
     ratio_ = check_ratio(ratio_func, y, 'over-sampling',
                          multiplier=multiplier)
     assert ratio_ == {1: 25, 2: 0, 3: 50}
+
+
+def test_hash_X_y():
+    rng = check_random_state(0)
+    X = rng.randn(2000, 20)
+    y = np.array([0] * 500 + [1] * 1500)
+    assert hash_X_y(X, y) == ('9ad0abc242757e8a67e5c8b0b4a4a675',
+                              '75ca7883d3814bc7a3df09b9d59eef78')
+
+    X = rng.randn(5, 2)
+    y = np.array([0] * 2 + [1] * 3)
+    # all data will be used in this case
+    assert hash_X_y(X, y) == (joblib.hash(X), joblib.hash(y))

--- a/imblearn/utils/tests/test_validation.py
+++ b/imblearn/utils/tests/test_validation.py
@@ -175,8 +175,8 @@ def test_hash_X_y():
     rng = check_random_state(0)
     X = rng.randn(2000, 20)
     y = np.array([0] * 500 + [1] * 1500)
-    assert hash_X_y(X, y) == ('9ad0abc242757e8a67e5c8b0b4a4a675',
-                              '75ca7883d3814bc7a3df09b9d59eef78')
+    assert hash_X_y(X, y, 10, 10) == (joblib.hash(X[::200, ::2]),
+                                      joblib.hash(y[::200]))
 
     X = rng.randn(5, 2)
     y = np.array([0] * 2 + [1] * 3)

--- a/imblearn/utils/validation.py
+++ b/imblearn/utils/validation.py
@@ -100,7 +100,6 @@ def hash_X_y(X, y, n_samples=10, n_features=5):
     -------
     X_hash: str
         Hash identifier of the ``X`` matrix.
-
     y_hash: str
         Hash identifier of the ``y`` matrix.
     """

--- a/imblearn/utils/validation.py
+++ b/imblearn/utils/validation.py
@@ -79,7 +79,7 @@ def check_target_type(y):
     return y
 
 
-def hash_X_y(X, y, n_samples=1000):
+def hash_X_y(X, y, n_samples=10, n_features=5):
     """Compute hash of the input arrays.
 
     Parameters
@@ -88,6 +88,13 @@ def hash_X_y(X, y, n_samples=1000):
         The ``X`` array.
 
     y : ndarray, shape (n_samples)
+        The ``y`` array.
+
+    n_samples : int, optional
+        The number of samples to use to compute the hash. Default is 100.
+
+    n_features : int, optional
+        The number of features to use to compute the hash. Default is 10.
 
     Returns
     -------
@@ -98,7 +105,7 @@ def hash_X_y(X, y, n_samples=1000):
         Hash identifier of the ``y`` matrix.
     """
     row_idx = slice(None, None, max(1, X.shape[0] // n_samples))
-    col_idx = slice(None, None, max(1, X.shape[1] // n_samples))
+    col_idx = slice(None, None, max(1, X.shape[1] // n_features))
 
     return joblib.hash(X[row_idx, col_idx]), joblib.hash(y[row_idx])
 

--- a/imblearn/utils/validation.py
+++ b/imblearn/utils/validation.py
@@ -2,6 +2,8 @@
 
 # Authors: Guillaume Lemaitre <g.lemaitre58@gmail.com>
 # License: MIT
+from __future__ import division
+
 import warnings
 from collections import Counter
 from numbers import Integral
@@ -95,11 +97,10 @@ def hash_X_y(X, y, n_samples=1000):
     y_hash: str
         Hash identifier of the ``y`` matrix.
     """
-    rng = np.random.RandomState(0)
-    raw_idx = rng.randint(X.shape[0], size=n_samples)
-    col_idx = rng.randint(X.shape[1], size=n_samples)
+    row_idx = slice(None, None, max(1, X.shape[0] // n_samples))
+    col_idx = slice(None, None, max(1, X.shape[1] // n_samples))
 
-    return joblib.hash(X[raw_idx, col_idx]), joblib.hash(y[raw_idx])
+    return joblib.hash(X[row_idx, col_idx]), joblib.hash(y[row_idx])
 
 
 def _ratio_all(y, sampling_type):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
closes #344 
closes: #365 


#### What does this implement/fix? Explain your changes.

Remove the fixed random_seed to compute the hash. Instead we pick-up equally spaced samples.
Since this is related, random_state has been deprecated whenever possible.

TODO: 

- [ ] tests

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
