### PR TITLE
[MRG] Fix logger name

### DIFF
--- a/imblearn/base.py
+++ b/imblearn/base.py
@@ -7,7 +7,6 @@
 from __future__ import division
 
 import logging
-import os
 from abc import ABCMeta, abstractmethod
 
 from sklearn.base import BaseEstimator

--- a/imblearn/base.py
+++ b/imblearn/base.py
@@ -7,6 +7,7 @@
 from __future__ import division
 
 import logging
+import os
 from abc import ABCMeta, abstractmethod
 
 from sklearn.base import BaseEstimator
@@ -119,7 +120,7 @@ class SamplerMixin(six.with_metaclass(ABCMeta, BaseEstimator)):
 
     def __setstate__(self, dict):
         """Re-open the logger."""
-        logger = logging.getLogger(__name__)
+        logger = logging.getLogger(self.__module__)
         self.__dict__.update(dict)
         self.logger = logger
 
@@ -133,7 +134,7 @@ class BaseSampler(SamplerMixin):
 
     def __init__(self, ratio='auto'):
         self.ratio = ratio
-        self.logger = logging.getLogger(__name__)
+        self.logger = logging.getLogger(self.__module__)
 
     def fit(self, X, y):
         """Find the classes statistics before to perform sampling.

--- a/imblearn/tests/test_common.py
+++ b/imblearn/tests/test_common.py
@@ -2,7 +2,6 @@
 # Authors: Guillaume Lemaitre <g.lemaitre58@gmail.com>
 #          Christos Aridas
 # License: MIT
-
 from sklearn.utils.testing import _named_check
 
 from imblearn.utils.estimator_checks import check_estimator, _yield_all_checks
@@ -34,3 +33,7 @@ def test_non_meta_estimators():
             continue
         for check in _yield_all_checks(name, Estimator):
             yield _named_check(check, name), name, Estimator
+
+            logger_name = Estimator().logger.name
+            class_module_name = Estimator.__module__
+            assert logger_name == class_module_name


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The logger in the `SamplerMixin` it was defined as `logging.getLogger(__name__)`. This has the side effect that all logging it is performed under the logger name `imblearn.base`. With the proposed approach the logger of a method it is named with the full module name in which the method belongs. 

We probably need a test for that change.
