### PR TITLE
EHN accept one-vs-all encoding for labels

### DIFF
--- a/doc/whats_new/v0.0.4.rst
+++ b/doc/whats_new/v0.0.4.rst
@@ -15,6 +15,9 @@ Enhancement
 - Document the metrics to evaluate models on imbalanced dataset. :issue:`367`
   by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- Add support for one-vs-all encoded target to support keras. :issue:`410` by
+  :user:`Guillaume Lemaitre <glemaitre>`.
+
 Bug fixes
 .........
 

--- a/doc/whats_new/v0.0.4.rst
+++ b/doc/whats_new/v0.0.4.rst
@@ -15,7 +15,7 @@ Enhancement
 - Document the metrics to evaluate models on imbalanced dataset. :issue:`367`
   by :user:`Guillaume Lemaitre <glemaitre>`.
 
-- Add support for one-vs-all encoded target to support keras. :issue:`410` by
+- Add support for one-vs-all encoded target to support keras. :issue:`409` by
   :user:`Guillaume Lemaitre <glemaitre>`.
 
 Bug fixes

--- a/imblearn/__init__.py
+++ b/imblearn/__init__.py
@@ -13,6 +13,9 @@ ensemble
 exceptions
     Module including custom warnings and error clases used across
     imbalanced-learn.
+keras
+    Module which provides custom generator, layers for deep learning using
+    keras.
 metrics
     Module which provides metrics to quantified the classification performance
     with imbalanced dataset.

--- a/imblearn/__init__.py
+++ b/imblearn/__init__.py
@@ -13,9 +13,6 @@ ensemble
 exceptions
     Module including custom warnings and error clases used across
     imbalanced-learn.
-keras
-    Module which provides custom generator, layers for deep learning using
-    keras.
 metrics
     Module which provides metrics to quantified the classification performance
     with imbalanced dataset.

--- a/imblearn/combine/smote_enn.py
+++ b/imblearn/combine/smote_enn.py
@@ -144,8 +144,8 @@ class SMOTEENN(SamplerMixin):
             Return self.
 
         """
-        X, y = check_X_y(X, y, accept_sparse=['csr', 'csc'])
         y = check_target_type(y)
+        X, y = check_X_y(X, y, accept_sparse=['csr', 'csc'])
         self.ratio_ = self.ratio
         self.X_hash_, self.y_hash_ = hash_X_y(X, y)
 

--- a/imblearn/combine/smote_tomek.py
+++ b/imblearn/combine/smote_tomek.py
@@ -8,7 +8,6 @@ links."""
 from __future__ import division
 
 import logging
-import warnings
 
 from sklearn.utils import check_X_y
 
@@ -153,8 +152,8 @@ SMOTETomek # doctest: +NORMALIZE_WHITESPACE
             Return self.
 
         """
-        X, y = check_X_y(X, y, accept_sparse=['csr', 'csc'])
         y = check_target_type(y)
+        X, y = check_X_y(X, y, accept_sparse=['csr', 'csc'])
         self.ratio_ = self.ratio
         self.X_hash_, self.y_hash_ = hash_X_y(X, y)
 

--- a/imblearn/ensemble/balance_cascade.py
+++ b/imblearn/ensemble/balance_cascade.py
@@ -14,7 +14,7 @@ from sklearn.utils import check_random_state, safe_indexing
 from sklearn.model_selection import cross_val_predict
 
 from .base import BaseEnsembleSampler
-from ..utils import check_ratio
+from ..utils import check_ratio, check_target_type
 
 
 class BalanceCascade(BaseEnsembleSampler):
@@ -137,6 +137,7 @@ BalanceCascade # doctest: +NORMALIZE_WHITESPACE
 
         """
         super(BalanceCascade, self).fit(X, y)
+        y = check_target_type(y)
         self.ratio_ = check_ratio(self.ratio, y, 'under-sampling')
         return self
 

--- a/imblearn/ensemble/base.py
+++ b/imblearn/ensemble/base.py
@@ -4,7 +4,14 @@ Base class for the ensemble method.
 # Authors: Guillaume Lemaitre <g.lemaitre58@gmail.com>
 # License: MIT
 
+import numpy as np
+
+from sklearn.preprocessing import label_binarize
+from sklearn.utils import check_X_y
+from sklearn.utils.validation import check_is_fitted
+
 from ..base import BaseSampler
+from ..utils import check_target_type
 
 
 class BaseEnsembleSampler(BaseSampler):
@@ -15,3 +22,46 @@ class BaseEnsembleSampler(BaseSampler):
     """
 
     _sampling_type = 'ensemble'
+
+    def sample(self, X, y):
+        """Resample the dataset.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+            Matrix containing the data which have to be sampled.
+
+        y : array-like, shape (n_samples,)
+            Corresponding label for each sample in X.
+
+        Returns
+        -------
+        X_resampled : {ndarray, sparse matrix}, shape \
+(n_subset, n_samples_new, n_features)
+            The array containing the resampled data.
+
+        y_resampled : ndarray, shape (n_subset, n_samples_new)
+            The corresponding label of `X_resampled`
+
+        """
+        # Ensemble are a bit specific since they are returning an array of
+        # resampled arrays.
+        y, binarize_y = check_target_type(y, indicate_one_vs_all=True)
+        X, y = check_X_y(X, y, accept_sparse=['csr', 'csc'])
+
+        check_is_fitted(self, 'ratio_')
+        self._check_X_y(X, y)
+
+        output = self._sample(X, y)
+
+        if binarize_y:
+            y_resampled = output[1]
+            classes = np.unique(y)
+            y_resampled_encoded = np.array([label_binarize(batch_y, classes)
+                                            for batch_y in y_resampled])
+            if len(output) == 2:
+                return output[0], y_resampled_encoded
+            else:
+                return output[0], y_resampled_encoded, output[2]
+        else:
+            return output

--- a/imblearn/utils/estimator_checks.py
+++ b/imblearn/utils/estimator_checks.py
@@ -269,5 +269,10 @@ def check_samplers_multiclass_ova(name, Sampler):
     X_res, y_res = sampler.fit_sample(X, y)
     X_res_ova, y_res_ova = sampler.fit_sample(X, y_ova)
     assert_allclose(X_res, X_res_ova)
-    assert type_of_target(y_res_ova) == type_of_target(y_ova)
-    assert_allclose(y_res, y_res_ova.argmax(axis=1))
+    if issubclass(Sampler, BaseEnsembleSampler):
+        for batch_y, batch_y_ova in zip(y_res, y_res_ova):
+            assert type_of_target(batch_y_ova) == type_of_target(y_ova)
+            assert_allclose(batch_y, batch_y_ova.argmax(axis=1))
+    else:
+        assert type_of_target(y_res_ova) == type_of_target(y_ova)
+        assert_allclose(y_res, y_res_ova.argmax(axis=1))

--- a/imblearn/utils/tests/test_validation.py
+++ b/imblearn/utils/tests/test_validation.py
@@ -6,17 +6,20 @@
 from collections import Counter
 
 import numpy as np
+import pytest
 from pytest import raises
 
 from sklearn.neighbors.base import KNeighborsMixin
 from sklearn.neighbors import NearestNeighbors
 from sklearn.utils import check_random_state
 from sklearn.externals import joblib
+from sklearn.utils.testing import assert_array_equal
 
 from imblearn.utils.testing import warns
 from imblearn.utils import check_neighbors_object
 from imblearn.utils import check_ratio
 from imblearn.utils import hash_X_y
+from imblearn.utils import check_target_type
 
 
 def test_check_neighbors_object():
@@ -34,6 +37,35 @@ def test_check_neighbors_object():
     with raises(ValueError, match="has to be one of"):
         check_neighbors_object(name, n_neighbors)
 
+
+@pytest.mark.parametrize(
+    "target, output_target",
+    [(np.array([0, 1, 1]), np.array([0, 1, 1])),
+     (np.array([0, 1, 2]), np.array([0, 1, 2])),
+     (np.array([[0, 1], [1, 0]]), np.array([1, 0]))]
+)
+def test_check_target_type(target, output_target):
+    converted_target = check_target_type(target.astype(int))
+    assert_array_equal(converted_target, output_target.astype(int))
+
+
+@pytest.mark.parametrize(
+    "target, output_target, is_ova",
+    [(np.array([0, 1, 1]), np.array([0, 1, 1]), False),
+     (np.array([0, 1, 2]), np.array([0, 1, 2]), False),
+     (np.array([[0, 1], [1, 0]]), np.array([1, 0]), True)]
+)
+def test_check_target_type_ova(target, output_target, is_ova):
+    converted_target, binarize_target = check_target_type(
+        target.astype(int), indicate_one_vs_all=True)
+    assert_array_equal(converted_target, output_target.astype(int))
+    assert binarize_target == is_ova
+
+
+def test_check_target_warning():
+    target = np.arange(4).reshape((2, 2))
+    with pytest.warns(UserWarning, message='should be of types'):
+        check_target_type(target)
 
 def test_check_ratio_error():
     with raises(ValueError, match="'sampling_type' should be one of"):

--- a/imblearn/utils/tests/test_validation.py
+++ b/imblearn/utils/tests/test_validation.py
@@ -64,7 +64,7 @@ def test_check_target_type_ova(target, output_target, is_ova):
 
 def test_check_target_warning():
     target = np.arange(4).reshape((2, 2))
-    with pytest.warns(UserWarning, message='should be of types'):
+    with pytest.warns(UserWarning, match='should be of types'):
         check_target_type(target)
 
 

--- a/imblearn/utils/tests/test_validation.py
+++ b/imblearn/utils/tests/test_validation.py
@@ -67,6 +67,7 @@ def test_check_target_warning():
     with pytest.warns(UserWarning, message='should be of types'):
         check_target_type(target)
 
+
 def test_check_ratio_error():
     with raises(ValueError, match="'sampling_type' should be one of"):
         check_ratio('auto', np.array([1, 2, 3]), 'rnd')

--- a/imblearn/utils/validation.py
+++ b/imblearn/utils/validation.py
@@ -10,7 +10,6 @@ from numbers import Integral
 
 import numpy as np
 
-from sklearn.preprocessing import label_binarize
 from sklearn.neighbors.base import KNeighborsMixin
 from sklearn.neighbors import NearestNeighbors
 from sklearn.externals import six, joblib

--- a/imblearn/utils/validation.py
+++ b/imblearn/utils/validation.py
@@ -10,6 +10,7 @@ from numbers import Integral
 
 import numpy as np
 
+from sklearn.preprocessing import label_binarize
 from sklearn.neighbors.base import KNeighborsMixin
 from sklearn.neighbors import NearestNeighbors
 from sklearn.externals import six, joblib
@@ -19,7 +20,7 @@ from ..exceptions import raise_isinstance_error
 
 SAMPLING_KIND = ('over-sampling', 'under-sampling', 'clean-sampling',
                  'ensemble')
-TARGET_KIND = ('binary', 'multiclass')
+TARGET_KIND = ('binary', 'multiclass', 'multilabel-indicator')
 
 
 def check_neighbors_object(nn_name, nn_object, additional_neighbor=0):
@@ -54,29 +55,42 @@ def check_neighbors_object(nn_name, nn_object, additional_neighbor=0):
         raise_isinstance_error(nn_name, [int, KNeighborsMixin], nn_object)
 
 
-def check_target_type(y):
+def check_target_type(y, indicate_one_vs_all=False):
     """Check the target types to be conform to the current samplers.
 
-    The current samplers should be compatible with ``'binary'`` and
-    ``'multiclass'`` targets only.
+    The current samplers should be compatible with ``'binary'``,
+    ``'multilabel-indicator'`` and ``'multiclass'`` targets only.
 
     Parameters
     ----------
     y : ndarray,
-        The array containing the target
+        The array containing the target.
+
+    indicate_one_vs_all : bool, optional
+        Either to indicate if the targets are encoded in a one-vs-all fashion.
 
     Returns
     -------
     y : ndarray,
         The returned target.
 
+    is_one_vs_all : bool, optional
+        Indicate if the target was originally encoded in a one-vs-all fashion.
+        Only returned if ``indicate_multilabel=True``.
+
     """
-    if type_of_target(y) not in TARGET_KIND:
+    type_y = type_of_target(y)
+    if type_y not in TARGET_KIND:
         # FIXME: perfectly we should raise an error but the sklearn API does
         # not allow for it
         warnings.warn("'y' should be of types {} only. Got {} instead.".format(
             TARGET_KIND, type_of_target(y)))
-    return y
+
+    if indicate_one_vs_all:
+        return (y.argmax(axis=1) if type_y == 'multilabel-indicator' else y,
+                type_y == 'multilabel-indicator')
+    else:
+        return y.argmax(axis=1) if type_y == 'multilabel-indicator' else y
 
 
 def hash_X_y(X, y, n_samples=10, n_features=5):


### PR DESCRIPTION
This PR allows user to provide targets which are one-vs-all encoded.
This is widely used in Keras for the loss function.

This is part of #409