### PR TITLE
[MRG] Consistent spelling error in documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *,cover
+.pytest_cache/
 
 # Translations
 *.mo
@@ -67,3 +68,6 @@ target/
 *.pyproj
 *.suo
 *.vs
+
+# PyCharm
+.idea/

--- a/imblearn/combine/smote_enn.py
+++ b/imblearn/combine/smote_enn.py
@@ -50,7 +50,7 @@ class SMOTEENN(SamplerMixin):
     -----
     The method is presented in [1]_.
 
-    Supports mutli-class resampling. Refer to SMOTE and ENN regarding the
+    Supports multi-class resampling. Refer to SMOTE and ENN regarding the
     scheme which used.
 
     See :ref:`sphx_glr_auto_examples_combine_plot_smote_enn.py` and

--- a/imblearn/combine/smote_tomek.py
+++ b/imblearn/combine/smote_tomek.py
@@ -57,7 +57,7 @@ class SMOTETomek(SamplerMixin):
     -----
     The methos is presented in [1]_.
 
-    Supports mutli-class resampling. Refer to SMOTE and TomekLinks regarding
+    Supports multi-class resampling. Refer to SMOTE and TomekLinks regarding
     the scheme which used.
 
     See :ref:`sphx_glr_auto_examples_combine_plot_smote_tomek.py` and

--- a/imblearn/ensemble/balance_cascade.py
+++ b/imblearn/ensemble/balance_cascade.py
@@ -63,7 +63,7 @@ class BalanceCascade(BaseEnsembleSampler):
     -----
     The method is described in [1]_.
 
-    Supports mutli-class resampling. A one-vs.-rest scheme is used as
+    Supports multi-class resampling. A one-vs.-rest scheme is used as
     originally proposed in [1]_.
 
     See :ref:`sphx_glr_auto_examples_ensemble_plot_balance_cascade.py`.

--- a/imblearn/ensemble/easy_ensemble.py
+++ b/imblearn/ensemble/easy_ensemble.py
@@ -53,7 +53,7 @@ class EasyEnsemble(BaseEnsembleSampler):
     -----
     The method is described in [1]_.
 
-    Supports mutli-class resampling by sampling each class independently.
+    Supports multi-class resampling by sampling each class independently.
 
     See :ref:`sphx_glr_auto_examples_ensemble_plot_easy_ensemble.py`.
 

--- a/imblearn/over_sampling/adasyn.py
+++ b/imblearn/over_sampling/adasyn.py
@@ -50,7 +50,7 @@ class ADASYN(BaseOverSampler):
     -----
     The implementation is based on [1]_.
 
-    Supports mutli-class resampling. A one-vs.-rest scheme is used.
+    Supports multi-class resampling. A one-vs.-rest scheme is used.
 
     See
     :ref:`sphx_glr_auto_examples_applications_plot_over_sampling_benchmark_lfw.py`,

--- a/imblearn/over_sampling/random_over_sampler.py
+++ b/imblearn/over_sampling/random_over_sampler.py
@@ -39,7 +39,7 @@ class RandomOverSampler(BaseOverSampler):
 
     Notes
     -----
-    Supports mutli-class resampling by sampling each class independently.
+    Supports multi-class resampling by sampling each class independently.
 
     See
     :ref:`sphx_glr_auto_examples_over-sampling_plot_comparison_over_sampling.py`,

--- a/imblearn/over_sampling/smote.py
+++ b/imblearn/over_sampling/smote.py
@@ -77,7 +77,7 @@ class SMOTE(BaseOverSampler):
     -----
     See the original papers: [1]_, [2]_, [3]_ for more details.
 
-    Supports mutli-class resampling. A one-vs.-rest scheme is used as
+    Supports multi-class resampling. A one-vs.-rest scheme is used as
     originally proposed in [1]_.
 
     See

--- a/imblearn/under_sampling/prototype_generation/cluster_centroids.py
+++ b/imblearn/under_sampling/prototype_generation/cluster_centroids.py
@@ -69,7 +69,7 @@ class ClusterCentroids(BaseUnderSampler):
 
     Notes
     -----
-    Supports mutli-class resampling by sampling each class independently.
+    Supports multi-class resampling by sampling each class independently.
 
     See :ref:`sphx_glr_auto_examples_under-sampling_plot_cluster_centroids.py`.
 

--- a/imblearn/under_sampling/prototype_selection/condensed_nearest_neighbour.py
+++ b/imblearn/under_sampling/prototype_selection/condensed_nearest_neighbour.py
@@ -62,7 +62,7 @@ KNeighborsClassifier(n_neighbors=1))
     -----
     The method is based on [1]_.
 
-    Supports mutli-class resampling. A one-vs.-rest scheme is used when
+    Supports multi-class resampling. A one-vs.-rest scheme is used when
     sampling a class as proposed in [1]_.
 
     See

--- a/imblearn/under_sampling/prototype_selection/edited_nearest_neighbours.py
+++ b/imblearn/under_sampling/prototype_selection/edited_nearest_neighbours.py
@@ -72,7 +72,7 @@ class EditedNearestNeighbours(BaseCleaningSampler):
     -----
     The method is based on [1]_.
 
-    Supports mutli-class resampling. A one-vs.-rest scheme is used when
+    Supports multi-class resampling. A one-vs.-rest scheme is used when
     sampling a class as proposed in [1]_.
 
     See
@@ -252,7 +252,7 @@ class RepeatedEditedNearestNeighbours(BaseCleaningSampler):
     The method is based on [1]_. A one-vs.-rest scheme is used when
     sampling a class as proposed in [1]_.
 
-    Supports mutli-class resampling.
+    Supports multi-class resampling.
 
     See
     :ref:`sphx_glr_auto_examples_pipeline_plot_pipeline_classification.py` and
@@ -464,7 +464,7 @@ class AllKNN(BaseCleaningSampler):
     -----
     The method is based on [1]_.
 
-    Supports mutli-class resampling. A one-vs.-rest scheme is used when
+    Supports multi-class resampling. A one-vs.-rest scheme is used when
     sampling a class as proposed in [1]_.
 
     See :ref:`sphx_glr_auto_examples_under-sampling_plot_enn_renn_allknn.py`.

--- a/imblearn/under_sampling/prototype_selection/instance_hardness_threshold.py
+++ b/imblearn/under_sampling/prototype_selection/instance_hardness_threshold.py
@@ -65,7 +65,7 @@ class InstanceHardnessThreshold(BaseCleaningSampler):
     -----
     The method is based on [1]_.
 
-    Supports mutli-class resampling. A one-vs.-rest scheme is used when
+    Supports multi-class resampling. A one-vs.-rest scheme is used when
     sampling a class as proposed in [1]_.
 
     See

--- a/imblearn/under_sampling/prototype_selection/nearmiss.py
+++ b/imblearn/under_sampling/prototype_selection/nearmiss.py
@@ -71,7 +71,7 @@ class NearMiss(BaseUnderSampler):
     -----
     The methods are based on [1]_.
 
-    Supports mutli-class resampling.
+    Supports multi-class resampling.
 
     See
     :ref:`sphx_glr_auto_examples_applications_plot_multi_class_under_sampling.py`

--- a/imblearn/under_sampling/prototype_selection/neighbourhood_cleaning_rule.py
+++ b/imblearn/under_sampling/prototype_selection/neighbourhood_cleaning_rule.py
@@ -72,7 +72,7 @@ class NeighbourhoodCleaningRule(BaseCleaningSampler):
     -----
     See the original paper: [1]_.
 
-    Supports mutli-class resampling. A one-vs.-rest scheme is used when
+    Supports multi-class resampling. A one-vs.-rest scheme is used when
     sampling a class as proposed in [1]_.
 
     See

--- a/imblearn/under_sampling/prototype_selection/one_sided_selection.py
+++ b/imblearn/under_sampling/prototype_selection/one_sided_selection.py
@@ -58,7 +58,7 @@ KNeighborsClassifier(n_neighbors=1))
     -----
     The method is based on [1]_.
 
-    Supports mutli-class resampling. A one-vs.-one scheme is used when sampling
+    Supports multi-class resampling. A one-vs.-one scheme is used when sampling
     a class as proposed in [1]_. For each class to be sampled, all samples of
     this class and the minority class are used during the sampling procedure.
 

--- a/imblearn/under_sampling/prototype_selection/random_under_sampler.py
+++ b/imblearn/under_sampling/prototype_selection/random_under_sampler.py
@@ -45,7 +45,7 @@ class RandomUnderSampler(BaseUnderSampler):
 
     Notes
     -----
-    Supports mutli-class resampling by sampling each class independently.
+    Supports multi-class resampling by sampling each class independently.
 
     See
     :ref:`sphx_glr_auto_examples_plot_sampling_strategy_usage.py` and

--- a/imblearn/under_sampling/prototype_selection/tomek_links.py
+++ b/imblearn/under_sampling/prototype_selection/tomek_links.py
@@ -50,7 +50,7 @@ class TomekLinks(BaseCleaningSampler):
     -----
     This method is based on [1]_.
 
-    Supports mutli-class resampling. A one-vs.-rest scheme is used as
+    Supports multi-class resampling. A one-vs.-rest scheme is used as
     originally proposed in [1]_.
 
     See


### PR DESCRIPTION
Just fixing the spelling of "multi".

Issue: https://github.com/scikit-learn-contrib/imbalanced-learn/issues/430
