### PR TITLE
Added link

### DIFF
--- a/imblearn/ensemble/easy_ensemble.py
+++ b/imblearn/ensemble/easy_ensemble.py
@@ -4,7 +4,7 @@
 #          Christos Aridas
 # License: MIT
 
-#EasyEnsemble is also called as BalancedBaggingClassifier
+""""EasyEnsemble is also called as BalancedBaggingClassifier"""
 import numpy as np
 
 from sklearn.utils import check_random_state

--- a/imblearn/ensemble/easy_ensemble.py
+++ b/imblearn/ensemble/easy_ensemble.py
@@ -4,6 +4,7 @@
 #          Christos Aridas
 # License: MIT
 
+#EasyEnsemble is also called as BalancedBaggingClassifier
 import numpy as np
 
 from sklearn.utils import check_random_state


### PR DESCRIPTION
Added a link to BalancedBaggingClassifier and EasyEnsemble

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
This is on issue #388 

#### What does this implement/fix?
I tried to add the link between EasyEnsemble and BalancedBaggingClassifier by documenting that they are synonyms in `easy_ensemble.py` file.
