### PR TITLE
BUG: Preserve dtype of X and y when generating samples

### DIFF
--- a/doc/whats_new/v0.0.4.rst
+++ b/doc/whats_new/v0.0.4.rst
@@ -63,6 +63,10 @@ Bug fixes
 - Force to clone scikit-learn estimator passed as attributes to samplers.
   :issue:`446` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- Fix bug which was not preserving the dtype of X and y when generating
+  samples.
+  issue:`448` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Maintenance
 ...........
 

--- a/imblearn/over_sampling/adasyn.py
+++ b/imblearn/over_sampling/adasyn.py
@@ -185,8 +185,9 @@ ADASYN # doctest: +NORMALIZE_WHITESPACE
                             n_samples_generated += 1
                 X_new = (sparse.csr_matrix(
                     (samples, (row_indices, col_indices)),
-                    [np.sum(n_samples_generate), X.shape[1]]))
-                y_new = np.array([class_sample] * np.sum(n_samples_generate))
+                    [np.sum(n_samples_generate), X.shape[1]], dtype=X.dtype))
+                y_new = np.array([class_sample] * np.sum(n_samples_generate),
+                                 dtype=y.dtype)
             else:
                 x_class_gen = []
                 for x_i, x_i_nn, num_sample_i in zip(X_class, nn_index,
@@ -201,8 +202,9 @@ ADASYN # doctest: +NORMALIZE_WHITESPACE
                         for step, nn_z in zip(steps, nn_zs)
                     ])
 
-                X_new = np.concatenate(x_class_gen)
-                y_new = np.array([class_sample] * np.sum(n_samples_generate))
+                X_new = np.concatenate(x_class_gen).astype(X.dtype)
+                y_new = np.array([class_sample] * np.sum(n_samples_generate),
+                                 dtype=y.dtype)
 
             if sparse.issparse(X_new):
                 X_resampled = sparse.vstack([X_resampled, X_new])

--- a/imblearn/under_sampling/prototype_generation/cluster_centroids.py
+++ b/imblearn/under_sampling/prototype_generation/cluster_centroids.py
@@ -128,10 +128,10 @@ ClusterCentroids # doctest: +NORMALIZE_WHITESPACE
             X_new = safe_indexing(X, np.squeeze(indices))
         else:
             if sparse.issparse(X):
-                X_new = sparse.csr_matrix(centroids)
+                X_new = sparse.csr_matrix(centroids, dtype=X.dtype)
             else:
                 X_new = centroids
-        y_new = np.array([target_class] * centroids.shape[0])
+        y_new = np.array([target_class] * centroids.shape[0], dtype=y.dtype)
 
         return X_new, y_new
 
@@ -191,4 +191,4 @@ ClusterCentroids # doctest: +NORMALIZE_WHITESPACE
             X_resampled = np.vstack(X_resampled)
         y_resampled = np.hstack(y_resampled)
 
-        return X_resampled, np.array(y_resampled)
+        return X_resampled, np.array(y_resampled, dtype=y.dtype)

--- a/imblearn/utils/estimator_checks.py
+++ b/imblearn/utils/estimator_checks.py
@@ -49,6 +49,7 @@ def _yield_sampler_checks(name, Estimator):
     yield check_samplers_sparse
     yield check_samplers_pandas
     yield check_samplers_multiclass_ova
+    yield check_samplers_preserve_dtype
 
 
 def _yield_all_checks(name, estimator):
@@ -333,3 +334,20 @@ def check_samplers_multiclass_ova(name, Sampler):
     else:
         assert type_of_target(y_res_ova) == type_of_target(y_ova)
         assert_allclose(y_res, y_res_ova.argmax(axis=1))
+
+
+def check_samplers_preserve_dtype(name, Sampler):
+    X, y = make_classification(
+        n_samples=1000,
+        n_classes=3,
+        n_informative=4,
+        weights=[0.2, 0.3, 0.5],
+        random_state=0)
+    # Cast X and y to not default dtype
+    X = X.astype(np.float32)
+    y = y.astype(np.int32)
+    sampler = Sampler()
+    set_random_state(sampler)
+    X_res, y_res = sampler.fit_sample(X, y)
+    assert X.dtype == X_res.dtype
+    assert y.dtype == y_res.dtype


### PR DESCRIPTION
closes #438 