### PR TITLE
Add memory to make_pipeline function

### DIFF
--- a/doc/whats_new/v0.0.4.rst
+++ b/doc/whats_new/v0.0.4.rst
@@ -76,6 +76,9 @@ Bug fixes
   samples.
   issue:`448` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- Add the option to pass a ``Memory`` object to :func:`make_pipeline` like 
+  in :class:`pipeline.Pipeline` class. Βy :user:`Christos Aridas <chkoar>`.
+
 Maintenance
 ...........
 

--- a/doc/whats_new/v0.0.4.rst
+++ b/doc/whats_new/v0.0.4.rst
@@ -74,10 +74,11 @@ Bug fixes
 
 - Fix bug which was not preserving the dtype of X and y when generating
   samples.
-  issue:`448` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :issue:`448` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 - Add the option to pass a ``Memory`` object to :func:`make_pipeline` like 
-  in :class:`pipeline.Pipeline` class. Βy :user:`Christos Aridas <chkoar>`.
+  in :class:`pipeline.Pipeline` class.
+  :issue:`458` by :user:`Christos Aridas <chkoar>`.
 
 Maintenance
 ...........

--- a/imblearn/pipeline.py
+++ b/imblearn/pipeline.py
@@ -600,15 +600,44 @@ def _fit_sample_one(sampler, X, y, **fit_params):
     return X_res, y_res, sampler
 
 
-def make_pipeline(*steps):
+def make_pipeline(*steps, **kwargs):
     """Construct a Pipeline from the given estimators.
-
     This is a shorthand for the Pipeline constructor; it does not require, and
     does not permit, naming the estimators. Instead, their names will be set
     to the lowercase of their types automatically.
-
+    Parameters
+    ----------
+    *steps : list of estimators.
+    memory : None, str or object with the joblib.Memory interface, optional
+        Used to cache the fitted transformers of the pipeline. By default,
+        no caching is performed. If a string is given, it is the path to
+        the caching directory. Enabling caching triggers a clone of
+        the transformers before fitting. Therefore, the transformer
+        instance given to the pipeline cannot be inspected
+        directly. Use the attribute ``named_steps`` or ``steps`` to
+        inspect estimators within the pipeline. Caching the
+        transformers is advantageous when fitting is time consuming.
+    See also
+    --------
+    imblearn.pipeline.Pipeline : Class for creating a pipeline of
+        transforms with a final estimator.
+    Examples
+    --------
+    >>> from sklearn.naive_bayes import GaussianNB
+    >>> from sklearn.preprocessing import StandardScaler
+    >>> make_pipeline(StandardScaler(), GaussianNB(priors=None))
+    ...     # doctest: +NORMALIZE_WHITESPACE
+    Pipeline(memory=None,
+             steps=[('standardscaler',
+                     StandardScaler(copy=True, with_mean=True, with_std=True)),
+                    ('gaussiannb',
+                     GaussianNB(priors=None, var_smoothing=1e-09))])
     Returns
     -------
     p : Pipeline
     """
-    return Pipeline(pipeline._name_estimators(steps))
+    memory = kwargs.pop('memory', None)
+    if kwargs:
+        raise TypeError('Unknown keyword arguments: "{}"'
+                        .format(list(kwargs.keys())[0]))
+    return Pipeline(pipeline._name_estimators(steps), memory=memory)

--- a/imblearn/pipeline.py
+++ b/imblearn/pipeline.py
@@ -617,6 +617,11 @@ def make_pipeline(*steps, **kwargs):
         directly. Use the attribute ``named_steps`` or ``steps`` to
         inspect estimators within the pipeline. Caching the
         transformers is advantageous when fitting is time consuming.
+
+    Returns
+    -------
+    p : Pipeline
+
     See also
     --------
     imblearn.pipeline.Pipeline : Class for creating a pipeline of
@@ -632,9 +637,6 @@ def make_pipeline(*steps, **kwargs):
                      StandardScaler(copy=True, with_mean=True, with_std=True)),
                     ('gaussiannb',
                      GaussianNB(priors=None))])
-    Returns
-    -------
-    p : Pipeline
     """
     memory = kwargs.pop('memory', None)
     if kwargs:

--- a/imblearn/pipeline.py
+++ b/imblearn/pipeline.py
@@ -631,7 +631,7 @@ def make_pipeline(*steps, **kwargs):
              steps=[('standardscaler',
                      StandardScaler(copy=True, with_mean=True, with_std=True)),
                     ('gaussiannb',
-                     GaussianNB(priors=None, var_smoothing=1e-09))])
+                     GaussianNB(priors=None))])
     Returns
     -------
     p : Pipeline

--- a/imblearn/pipeline.py
+++ b/imblearn/pipeline.py
@@ -602,12 +602,15 @@ def _fit_sample_one(sampler, X, y, **fit_params):
 
 def make_pipeline(*steps, **kwargs):
     """Construct a Pipeline from the given estimators.
+
     This is a shorthand for the Pipeline constructor; it does not require, and
     does not permit, naming the estimators. Instead, their names will be set
     to the lowercase of their types automatically.
+
     Parameters
     ----------
     *steps : list of estimators.
+
     memory : None, str or object with the joblib.Memory interface, optional
         Used to cache the fitted transformers of the pipeline. By default,
         no caching is performed. If a string is given, it is the path to
@@ -626,6 +629,7 @@ def make_pipeline(*steps, **kwargs):
     --------
     imblearn.pipeline.Pipeline : Class for creating a pipeline of
         transforms with a final estimator.
+
     Examples
     --------
     >>> from sklearn.naive_bayes import GaussianNB

--- a/imblearn/tests/test_pipeline.py
+++ b/imblearn/tests/test_pipeline.py
@@ -26,7 +26,7 @@ from sklearn.cluster import KMeans
 from sklearn.feature_selection import SelectKBest, f_classif
 from sklearn.datasets import load_iris, make_classification
 from sklearn.preprocessing import StandardScaler
-from sklearn.externals.joblib import Memory, __version__ as joblib_version
+from sklearn.externals.joblib import Memory
 
 from imblearn.pipeline import Pipeline, make_pipeline
 from imblearn.under_sampling import (RandomUnderSampler,

--- a/imblearn/tests/test_pipeline.py
+++ b/imblearn/tests/test_pipeline.py
@@ -5,7 +5,6 @@ Test the pipeline module.
 #          Christos Aridas
 # License: MIT
 
-from distutils.version import LooseVersion
 from tempfile import mkdtemp
 import shutil
 import time
@@ -1080,14 +1079,11 @@ def test_pipeline_fit_then_sample_3_samplers_with_sampler_last_estimator():
 
 def test_make_pipeline_memory():
     cachedir = mkdtemp()
-    if LooseVersion(joblib_version) < LooseVersion('0.12'):
-        # Deal with change of API in joblib
+    try:
         memory = Memory(cachedir=cachedir, verbose=10)
-    else:
-        memory = Memory(location=cachedir, verbose=10)
-    pipeline = make_pipeline(DummyTransf(), SVC(), memory=memory)
-    assert_true(pipeline.memory is memory)
-    pipeline = make_pipeline(DummyTransf(), SVC())
-    assert_true(pipeline.memory is None)
-
-    shutil.rmtree(cachedir)
+        pipeline = make_pipeline(DummyTransf(), SVC(), memory=memory)
+        assert pipeline.memory is memory
+        pipeline = make_pipeline(DummyTransf(), SVC())
+        assert pipeline.memory is None
+    finally:
+        shutil.rmtree(cachedir)

--- a/imblearn/tests/test_pipeline.py
+++ b/imblearn/tests/test_pipeline.py
@@ -1078,8 +1078,6 @@ def test_pipeline_fit_then_sample_3_samplers_with_sampler_last_estimator():
     assert_array_equal(y_fit_sample_resampled, y_fit_then_sample_res)
 
 
-
-
     def test_make_pipeline_memory():
         cachedir = mkdtemp()
         if LooseVersion(joblib_version) < LooseVersion('0.12'):

--- a/imblearn/tests/test_pipeline.py
+++ b/imblearn/tests/test_pipeline.py
@@ -1078,16 +1078,16 @@ def test_pipeline_fit_then_sample_3_samplers_with_sampler_last_estimator():
     assert_array_equal(y_fit_sample_resampled, y_fit_then_sample_res)
 
 
-    def test_make_pipeline_memory():
-        cachedir = mkdtemp()
-        if LooseVersion(joblib_version) < LooseVersion('0.12'):
-            # Deal with change of API in joblib
-            memory = Memory(cachedir=cachedir, verbose=10)
-        else:
-            memory = Memory(location=cachedir, verbose=10)
-        pipeline = make_pipeline(DummyTransf(), SVC(), memory=memory)
-        assert_true(pipeline.memory is memory)
-        pipeline = make_pipeline(DummyTransf(), SVC())
-        assert_true(pipeline.memory is None)
+def test_make_pipeline_memory():
+    cachedir = mkdtemp()
+    if LooseVersion(joblib_version) < LooseVersion('0.12'):
+        # Deal with change of API in joblib
+        memory = Memory(cachedir=cachedir, verbose=10)
+    else:
+        memory = Memory(location=cachedir, verbose=10)
+    pipeline = make_pipeline(DummyTransf(), SVC(), memory=memory)
+    assert_true(pipeline.memory is memory)
+    pipeline = make_pipeline(DummyTransf(), SVC())
+    assert_true(pipeline.memory is None)
 
-        shutil.rmtree(cachedir)
+    shutil.rmtree(cachedir)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Adds the ability to pass a joblib.Memory object to the `make_pipeline` function.

