### PR TITLE
MAINT: deprecate return_indices in favor of attribute sample_indices_

### DIFF
--- a/imblearn/ensemble/_weight_boosting.py
+++ b/imblearn/ensemble/_weight_boosting.py
@@ -169,8 +169,7 @@ class RUSBoostClassifier(AdaBoostClassifier):
 
         self.base_sampler_ = RandomUnderSampler(
             sampling_strategy=self.sampling_strategy,
-            replacement=self.replacement,
-            return_indices=True)
+            replacement=self.replacement)
 
     def _make_sampler_estimator(self, append=True, random_state=None):
         """Make and configure a copy of the `base_estimator_` attribute.
@@ -191,9 +190,6 @@ class RUSBoostClassifier(AdaBoostClassifier):
             self.samplers_.append(sampler)
             self.pipelines_.append(make_pipeline(deepcopy(sampler),
                                                  deepcopy(estimator)))
-            # do not return the indices within a pipeline
-            self.pipelines_[-1].named_steps['randomundersampler'].set_params(
-                return_indices=False)
 
         return estimator, sampler
 
@@ -202,8 +198,9 @@ class RUSBoostClassifier(AdaBoostClassifier):
         estimator, sampler = self._make_sampler_estimator(
             random_state=random_state)
 
-        X_res, y_res, idx_res = sampler.fit_resample(X, y)
-        sample_weight_res = safe_indexing(sample_weight, idx_res)
+        X_res, y_res = sampler.fit_resample(X, y)
+        sample_weight_res = safe_indexing(sample_weight,
+                                          sampler.sample_indices_)
         estimator.fit(X_res, y_res, sample_weight=sample_weight_res)
 
         y_predict_proba = estimator.predict_proba(X)
@@ -263,8 +260,9 @@ class RUSBoostClassifier(AdaBoostClassifier):
         estimator, sampler = self._make_sampler_estimator(
             random_state=random_state)
 
-        X_res, y_res, idx_res = sampler.fit_resample(X, y)
-        sample_weight_res = safe_indexing(sample_weight, idx_res)
+        X_res, y_res = sampler.fit_resample(X, y)
+        sample_weight_res = safe_indexing(sample_weight,
+                                          sampler.sample_indices_)
         estimator.fit(X_res, y_res, sample_weight=sample_weight_res)
 
         y_predict = estimator.predict(X)

--- a/imblearn/over_sampling/_random_over_sampler.py
+++ b/imblearn/over_sampling/_random_over_sampler.py
@@ -13,6 +13,7 @@ from sklearn.utils import check_X_y, check_random_state, safe_indexing
 from .base import BaseOverSampler
 from ..utils import check_target_type
 from ..utils import Substitution
+from ..utils.deprecation import deprecate_parameter
 from ..utils._docstring import _random_state_docstring
 
 
@@ -37,10 +38,22 @@ class RandomOverSampler(BaseOverSampler):
         Whether or not to return the indices of the samples randomly selected
         in the corresponding classes.
 
+        .. deprecated:: 0.4
+           ``return_indices`` is deprecated. Use the attribute
+           ``sample_indices_`` instead.
+
     ratio : str, dict, or callable
         .. deprecated:: 0.4
            Use the parameter ``sampling_strategy`` instead. It will be removed
            in 0.6.
+
+    Attributes
+    ----------
+    sample_indices_ : ndarray, shape (n_new_samples)
+        Indices of the samples selected.
+
+        .. versionadded:: 0.4
+           ``sample_indices_`` used instead of ``return_indices=True``.
 
     Notes
     -----
@@ -83,6 +96,10 @@ RandomOverSampler # doctest: +NORMALIZE_WHITESPACE
         return X, y, binarize_y
 
     def _fit_resample(self, X, y):
+        if self.return_indices:
+            deprecate_parameter(self, '0.4', 'return_indices',
+                                'sample_indices_')
+
         random_state = check_random_state(self.random_state)
         target_stats = Counter(y)
 
@@ -95,10 +112,10 @@ RandomOverSampler # doctest: +NORMALIZE_WHITESPACE
 
             sample_indices = np.append(sample_indices,
                                        target_class_indices[indices])
+        self.sample_indices_ = np.array(sample_indices)
 
         if self.return_indices:
-            return (safe_indexing(X, sample_indices), safe_indexing(
-                    y, sample_indices), sample_indices)
-        else:
-            return (safe_indexing(X, sample_indices), safe_indexing(
-                    y, sample_indices))
+            return (safe_indexing(X, sample_indices),
+                    safe_indexing(y, sample_indices), sample_indices)
+        return (safe_indexing(X, sample_indices),
+                safe_indexing(y, sample_indices))

--- a/imblearn/over_sampling/tests/test_random_over_sampler.py
+++ b/imblearn/over_sampling/tests/test_random_over_sampler.py
@@ -5,6 +5,7 @@
 
 from collections import Counter
 
+import pytest
 import numpy as np
 from sklearn.utils.testing import assert_allclose
 from sklearn.utils.testing import assert_array_equal
@@ -59,6 +60,7 @@ def test_ros_fit_resample_half():
     assert_array_equal(y_resampled, y_gt)
 
 
+@pytest.mark.filterwarnings("ignore:'return_indices' is deprecated from 0.4")
 def test_random_over_sampling_return_indices():
     ros = RandomOverSampler(return_indices=True, random_state=RND_SEED)
     X_resampled, y_resampled, sample_indices = ros.fit_resample(X, Y)

--- a/imblearn/under_sampling/_prototype_selection/_instance_hardness_threshold.py
+++ b/imblearn/under_sampling/_prototype_selection/_instance_hardness_threshold.py
@@ -19,6 +19,7 @@ from sklearn.utils import safe_indexing
 
 from ..base import BaseUnderSampler
 from ...utils import Substitution
+from ...utils.deprecation import deprecate_parameter
 from ...utils._docstring import _random_state_docstring
 
 
@@ -46,7 +47,11 @@ class InstanceHardnessThreshold(BaseUnderSampler):
 
     return_indices : bool, optional (default=False)
         Whether or not to return the indices of the samples randomly
-        selected from the majority class.
+        selected.
+
+        .. deprecated:: 0.4
+           ``return_indices`` is deprecated. Use the attribute
+           ``sample_indices_`` instead.
 
     {random_state}
 
@@ -60,6 +65,14 @@ class InstanceHardnessThreshold(BaseUnderSampler):
         .. deprecated:: 0.4
            Use the parameter ``sampling_strategy`` instead. It will be removed
            in 0.6.
+
+    Attributes
+    ----------
+    sample_indices_ : ndarray, shape (n_new_samples)
+        Indices of the samples selected.
+
+        .. versionadded:: 0.4
+           ``sample_indices_`` used instead of ``return_indices=True``.
 
     Notes
     -----
@@ -124,6 +137,9 @@ class InstanceHardnessThreshold(BaseUnderSampler):
                 type(self.estimator)))
 
     def _fit_resample(self, X, y):
+        if self.return_indices:
+            deprecate_parameter(self, '0.4', 'return_indices',
+                               'sample_indices_')
         self._validate_estimator()
 
         target_stats = Counter(y)
@@ -165,8 +181,9 @@ class InstanceHardnessThreshold(BaseUnderSampler):
                  np.flatnonzero(y == target_class)[index_target_class]),
                 axis=0)
 
+        self.sample_indices_ = idx_under
+
         if self.return_indices:
             return (safe_indexing(X, idx_under), safe_indexing(y, idx_under),
                     idx_under)
-        else:
-            return safe_indexing(X, idx_under), safe_indexing(y, idx_under)
+        return safe_indexing(X, idx_under), safe_indexing(y, idx_under)

--- a/imblearn/under_sampling/_prototype_selection/_nearmiss.py
+++ b/imblearn/under_sampling/_prototype_selection/_nearmiss.py
@@ -36,6 +36,10 @@ class NearMiss(BaseUnderSampler):
         Whether or not to return the indices of the samples randomly
         selected from the majority class.
 
+        .. deprecated:: 0.4
+           ``return_indices`` is deprecated. Use the attribute
+           ``sample_indices_`` instead.
+
     {random_state}
 
         .. deprecated:: 0.4
@@ -66,6 +70,14 @@ class NearMiss(BaseUnderSampler):
         .. deprecated:: 0.4
            Use the parameter ``sampling_strategy`` instead. It will be removed
            in 0.6.
+
+    Attributes
+    ----------
+    sample_indices_ : ndarray, shape (n_new_samples)
+        Indices of the samples selected.
+
+        .. versionadded:: 0.4
+           ``sample_indices_`` used instead of ``return_indices=True``.
 
     Notes
     -----
@@ -207,6 +219,9 @@ NearMiss # doctest: +NORMALIZE_WHITESPACE
                              ' {}'.format(self.version))
 
     def _fit_resample(self, X, y):
+        if self.return_indices:
+            deprecate_parameter(self, '0.4', 'return_indices',
+                                'sample_indices_')
         self._validate_estimator()
 
         idx_under = np.empty((0, ), dtype=int)
@@ -272,8 +287,9 @@ NearMiss # doctest: +NORMALIZE_WHITESPACE
                  np.flatnonzero(y == target_class)[index_target_class]),
                 axis=0)
 
+        self.sample_indices_ = idx_under
+
         if self.return_indices:
             return (safe_indexing(X, idx_under), safe_indexing(y, idx_under),
                     idx_under)
-        else:
-            return safe_indexing(X, idx_under), safe_indexing(y, idx_under)
+        return safe_indexing(X, idx_under), safe_indexing(y, idx_under)

--- a/imblearn/under_sampling/_prototype_selection/_one_sided_selection.py
+++ b/imblearn/under_sampling/_prototype_selection/_one_sided_selection.py
@@ -17,6 +17,7 @@ from sklearn.utils import check_random_state, safe_indexing
 from ..base import BaseCleaningSampler
 from ._tomek_links import TomekLinks
 from ...utils import Substitution
+from ...utils.deprecation import deprecate_parameter
 from ...utils._docstring import _random_state_docstring
 
 
@@ -34,7 +35,11 @@ class OneSidedSelection(BaseCleaningSampler):
 
     return_indices : bool, optional (default=False)
         Whether or not to return the indices of the samples randomly
-        selected from the majority class.
+        selected.
+
+        .. deprecated:: 0.4
+           ``return_indices`` is deprecated. Use the attribute
+           ``sample_indices_`` instead.
 
     {random_state}
 
@@ -55,6 +60,14 @@ KNeighborsClassifier(n_neighbors=1))
         .. deprecated:: 0.4
            Use the parameter ``sampling_strategy`` instead. It will be removed
            in 0.6.
+
+    Attributes
+    ----------
+    sample_indices_ : ndarray, shape (n_new_samples)
+        Indices of the samples selected.
+
+        .. versionadded:: 0.4
+           ``sample_indices_`` used instead of ``return_indices=True``.
 
     Notes
     -----
@@ -120,6 +133,9 @@ KNeighborsClassifier(n_neighbors=1))
                              ' Got {} instead.'.format(type(self.n_neighbors)))
 
     def _fit_resample(self, X, y):
+        if self.return_indices:
+            deprecate_parameter(self, '0.4', 'return_indices',
+                                'sample_indices_')
         self._validate_estimator()
 
         random_state = check_random_state(self.random_state)
@@ -171,8 +187,7 @@ KNeighborsClassifier(n_neighbors=1))
         X_cleaned, y_cleaned, idx_cleaned = tl.fit_resample(
             X_resampled, y_resampled)
 
-        idx_under = safe_indexing(idx_under, idx_cleaned)
+        self.sample_indices_ = safe_indexing(idx_under, idx_cleaned)
         if self.return_indices:
-            return (X_cleaned, y_cleaned, idx_under)
-        else:
-            return X_cleaned, y_cleaned
+            return (X_cleaned, y_cleaned, self.sample_indices_)
+        return X_cleaned, y_cleaned

--- a/imblearn/under_sampling/_prototype_selection/_random_under_sampler.py
+++ b/imblearn/under_sampling/_prototype_selection/_random_under_sampler.py
@@ -16,6 +16,7 @@ from sklearn.utils import safe_indexing
 from ..base import BaseUnderSampler
 from ...utils import check_target_type
 from ...utils import Substitution
+from ...utils.deprecation import deprecate_parameter
 from ...utils._docstring import _random_state_docstring
 
 
@@ -35,8 +36,11 @@ class RandomUnderSampler(BaseUnderSampler):
     {sampling_strategy}
 
     return_indices : bool, optional (default=False)
-        Whether or not to return the indices of the samples randomly selected
-        from the majority class.
+        Whether or not to return the indices of the samples randomly selected.
+
+        .. deprecated:: 0.4
+           ``return_indices`` is deprecated. Use the attribute
+           ``sample_indices_`` instead.
 
     {random_state}
 
@@ -47,6 +51,14 @@ class RandomUnderSampler(BaseUnderSampler):
         .. deprecated:: 0.4
            Use the parameter ``sampling_strategy`` instead. It will be removed
            in 0.6.
+
+    Attributes
+    ----------
+    sample_indices_ : ndarray, shape (n_new_samples)
+        Indices of the samples selected.
+
+        .. versionadded:: 0.4
+           ``sample_indices_`` used instead of ``return_indices=True``.
 
     Notes
     -----
@@ -95,6 +107,9 @@ RandomUnderSampler # doctest: +NORMALIZE_WHITESPACE
         return X, y, binarize_y
 
     def _fit_resample(self, X, y):
+        if self.return_indices:
+            deprecate_parameter(self, '0.4', 'return_indices',
+                                'sample_indices_')
         random_state = check_random_state(self.random_state)
 
         idx_under = np.empty((0, ), dtype=int)
@@ -114,8 +129,9 @@ RandomUnderSampler # doctest: +NORMALIZE_WHITESPACE
                  np.flatnonzero(y == target_class)[index_target_class]),
                 axis=0)
 
+        self.sample_indices_ = idx_under
+
         if self.return_indices:
             return (safe_indexing(X, idx_under), safe_indexing(y, idx_under),
                     idx_under)
-        else:
-            return safe_indexing(X, idx_under), safe_indexing(y, idx_under)
+        return safe_indexing(X, idx_under), safe_indexing(y, idx_under)

--- a/imblearn/under_sampling/_prototype_selection/_tomek_links.py
+++ b/imblearn/under_sampling/_prototype_selection/_tomek_links.py
@@ -31,7 +31,12 @@ class TomekLinks(BaseCleaningSampler):
 
     return_indices : bool, optional (default=False)
         Whether or not to return the indices of the samples randomly
-        selected from the majority class.
+        selected.
+
+        .. deprecated:: 0.4
+           ``return_indices`` is deprecated. Use the attribute
+           ``sample_indices_`` instead.
+
 
     {random_state}
 
@@ -45,6 +50,14 @@ class TomekLinks(BaseCleaningSampler):
         .. deprecated:: 0.4
            Use the parameter ``sampling_strategy`` instead. It will be removed
            in 0.6.
+
+    Attributes
+    ----------
+    sample_indices_ : ndarray, shape (n_new_samples)
+        Indices of the samples selected.
+
+        .. versionadded:: 0.4
+           ``sample_indices_`` used instead of ``return_indices=True``.
 
     Notes
     -----
@@ -132,6 +145,9 @@ TomekLinks # doctest: +NORMALIZE_WHITESPACE
         return links
 
     def _fit_resample(self, X, y):
+        if self.return_indices:
+            deprecate_parameter(self, '0.4', 'return_indices',
+                                'sample_indices_')
         # check for deprecated random_state
         if self.random_state is not None:
             deprecate_parameter(self, '0.4', 'random_state')
@@ -142,10 +158,10 @@ TomekLinks # doctest: +NORMALIZE_WHITESPACE
         nns = nn.kneighbors(X, return_distance=False)[:, 1]
 
         links = self.is_tomek(y, nns, self.sampling_strategy_)
-        idx_under = np.flatnonzero(np.logical_not(links))
+        self.sample_indices_ = np.flatnonzero(np.logical_not(links))
 
         if self.return_indices:
-            return (safe_indexing(X, idx_under), safe_indexing(y, idx_under),
-                    idx_under)
-        else:
-            return (safe_indexing(X, idx_under), safe_indexing(y, idx_under))
+            return (safe_indexing(X, self.sample_indices_),
+                    safe_indexing(y, self.sample_indices_), self.sample_indices_)
+        return (safe_indexing(X, self.sample_indices_),
+                safe_indexing(y, self.sample_indices_))

--- a/imblearn/under_sampling/_prototype_selection/tests/test_allknn.py
+++ b/imblearn/under_sampling/_prototype_selection/tests/test_allknn.py
@@ -3,8 +3,8 @@
 #          Christos Aridas
 # License: MIT
 
+import pytest
 import numpy as np
-from pytest import raises
 
 from sklearn.utils.testing import assert_allclose, assert_array_equal
 from sklearn.neighbors import NearestNeighbors
@@ -94,6 +94,7 @@ def test_all_knn_allow_minority():
     assert len(y_res_1) < len(y_res_2)
 
 
+@pytest.mark.filterwarnings("ignore:'return_indices' is deprecated from 0.4")
 def test_allknn_fit_resample_with_indices():
     allknn = AllKNN(return_indices=True)
     X_resampled, y_resampled, idx_under = allknn.fit_resample(X, Y)
@@ -196,7 +197,7 @@ def test_allknn_fit_resample_with_nn_object():
 def test_alknn_not_good_object():
     nn = 'rnd'
     allknn = AllKNN(n_neighbors=nn, kind_sel='mode')
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         allknn.fit_resample(X, Y)
 
 

--- a/imblearn/under_sampling/_prototype_selection/tests/test_edited_nearest_neighbours.py
+++ b/imblearn/under_sampling/_prototype_selection/tests/test_edited_nearest_neighbours.py
@@ -3,8 +3,8 @@
 #          Christos Aridas
 # License: MIT
 
+import pytest
 import numpy as np
-from pytest import raises
 
 from sklearn.utils.testing import assert_array_equal
 
@@ -50,6 +50,7 @@ def test_enn_fit_resample():
     assert_array_equal(y_resampled, y_gt)
 
 
+@pytest.mark.filterwarnings("ignore:'return_indices' is deprecated from 0.4")
 def test_enn_fit_resample_with_indices():
     enn = EditedNearestNeighbours(return_indices=True)
     X_resampled, y_resampled, idx_under = enn.fit_resample(X, Y)
@@ -103,7 +104,7 @@ def test_enn_fit_resample_with_nn_object():
 def test_enn_not_good_object():
     nn = 'rnd'
     enn = EditedNearestNeighbours(n_neighbors=nn, kind_sel='mode')
-    with raises(ValueError, match="has to be one of"):
+    with pytest.raises(ValueError, match="has to be one of"):
         enn.fit_resample(X, Y)
 
 

--- a/imblearn/under_sampling/_prototype_selection/tests/test_repeated_edited_nearest_neighbours.py
+++ b/imblearn/under_sampling/_prototype_selection/tests/test_repeated_edited_nearest_neighbours.py
@@ -3,8 +3,8 @@
 #          Christos Aridas
 # License: MIT
 
+import pytest
 import numpy as np
-from pytest import raises
 
 from sklearn.utils.testing import assert_array_equal
 from sklearn.neighbors import NearestNeighbors
@@ -54,7 +54,7 @@ def test_renn_init():
 def test_renn_iter_wrong():
     max_iter = -1
     renn = RepeatedEditedNearestNeighbours(max_iter=max_iter)
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         renn.fit_resample(X, Y)
 
 
@@ -86,6 +86,7 @@ def test_renn_fit_resample():
     assert_array_equal(y_resampled, y_gt)
 
 
+@pytest.mark.filterwarnings("ignore:'return_indices' is deprecated from 0.4")
 def test_renn_fit_resample_with_indices():
     renn = RepeatedEditedNearestNeighbours(return_indices=True)
     X_resampled, y_resampled, idx_under = renn.fit_resample(X, Y)
@@ -191,7 +192,7 @@ def test_renn_fit_resample_mode():
 def test_renn_not_good_object():
     nn = 'rnd'
     renn = RepeatedEditedNearestNeighbours(n_neighbors=nn, kind_sel='mode')
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         renn.fit_resample(X, Y)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,6 @@ test = pytest
 addopts =
     --doctest-modules
 
-# filterwarnings =
-#     error::DeprecationWarning
-#     error::FutureWarning
+filterwarnings =
+    error::DeprecationWarning
+    error::FutureWarning


### PR DESCRIPTION
``return_indices`` allowed to return an array with the selected samples for a specific sampler. This is actually not use in the usual scikit-learn API. Instead, we created a ``sample_indices_`` attribute instead.