### PR TITLE
FIX: SMOTENC should use half of the median of the std. dev.

### DIFF
--- a/doc/whats_new/v0.0.4.rst
+++ b/doc/whats_new/v0.0.4.rst
@@ -1,5 +1,19 @@
 .. _changes_0_4:
 
+Version 0.4.2
+=============
+
+Changelog
+---------
+
+Bug fixes
+.........
+
+- Fix a bug in :class:`imblearn.over_sampling.SMOTENC` in which the the median
+  of the standard deviation instead of half of the median of the standard
+  deviation.
+  By :user:`Guillaume Lemaitre <glemaitre>` in :issue:`491`.
+
 Version 0.4
 ===========
 

--- a/imblearn/over_sampling/_smote.py
+++ b/imblearn/over_sampling/_smote.py
@@ -974,7 +974,7 @@ class SMOTENC(SMOTE):
         # distance is computed between 2 samples, the difference will be equal
         # to the median of the standard deviation as in the original paper.
         X_ohe.data = (np.ones_like(X_ohe.data, dtype=X_ohe.dtype) *
-                      self.median_std_)
+                      self.median_std_ / 2)
         X_encoded = sparse.hstack((X_continuous, X_ohe), format='csr')
 
         X_resampled, y_resampled = super(SMOTENC, self)._fit_resample(


### PR DESCRIPTION
bug fix in SMOTE-NC