### PR TITLE
FIX: detect ill-pose sampling-strategy as a float

### DIFF
--- a/imblearn/utils/_validation.py
+++ b/imblearn/utils/_validation.py
@@ -317,6 +317,11 @@ def _sampling_strategy_float(sampling_strategy, y, sampling_type):
             key: int(n_sample_majority * sampling_strategy - value)
             for (key, value) in target_stats.items() if key != class_majority
         }
+        if any([n_samples <= 0 for n_samples in sampling_strategy_.values()]):
+            raise ValueError("The specified ratio required to remove samples "
+                             "from the minority class while trying to "
+                             "generate new samples. Please increase the "
+                             "ratio.")
     elif (sampling_type == 'under-sampling'):
         n_sample_minority = min(target_stats.values())
         class_minority = min(target_stats, key=target_stats.get)
@@ -324,6 +329,11 @@ def _sampling_strategy_float(sampling_strategy, y, sampling_type):
             key: int(n_sample_minority / sampling_strategy)
             for (key, value) in target_stats.items() if key != class_minority
         }
+        if any([n_samples > target_stats[target]
+               for target, n_samples in sampling_strategy_.items()]):
+            raise ValueError("The specified ratio required to generate new "
+                             "sample in the majority class while trying to "
+                             " remove samples. Please increase the ratio.")
     else:
         raise ValueError("'clean-sampling' methods do let the user "
                          "specify the sampling ratio.")

--- a/imblearn/utils/tests/test_validation.py
+++ b/imblearn/utils/tests/test_validation.py
@@ -70,10 +70,18 @@ def test_check_sampling_strategy_warning():
         }, multiclass_target, 'clean-sampling')
 
 
-def test_check_sampling_strategy_float_error():
-    msg = "'clean-sampling' methods do let the user specify the sampling ratio"
-    with pytest.raises(ValueError, match=msg):
-        check_sampling_strategy(0.5, binary_target, 'clean-sampling')
+@pytest.mark.parametrize(
+    "ratio, y, type, err_msg",
+    [(0.5, binary_target, 'clean-sampling',
+      "'clean-sampling' methods do let the user specify the sampling ratio"),
+      (0.1, np.array([0] * 10 + [1] * 20), 'over-sampling',
+       "remove samples from the minority class while trying to generate new"),
+      (0.1, np.array([0] * 10 + [1] * 20), 'under-sampling',
+       "generate new samples in the majority class while trying to remove")]
+)
+def test_check_sampling_strategy_float_error(ratio, y, type, err_msg):
+    with pytest.raises(ValueError, match=err_msg):
+        check_sampling_strategy(ratio, y, type)
 
 
 def test_check_sampling_strategy_error():


### PR DESCRIPTION
Fixes corner case with understandable errors. Crashing was happening when:

* a ratio was given forcing to generate new-sample in under-sampling methods,
* a ratio was given forcing to remove sample in over-sampling methods.