### PR TITLE
DOC: add borderline- and SVM-SMOTE to the API doc

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -70,9 +70,11 @@ Prototype selection
    :template: class.rst
 
    over_sampling.ADASYN
+   over_sampling.BorderlineSMOTE
    over_sampling.RandomOverSampler
    over_sampling.SMOTE
    over_sampling.SMOTENC
+   over_sampling.SVMSMOTE
 
 
 .. _combine_ref:

--- a/doc/whats_new/v0.5.rst
+++ b/doc/whats_new/v0.5.rst
@@ -13,6 +13,10 @@ Documentation
   strategy for the over-sampling and under-sampling.
   :issue:`525` by :user:`Ariel Rossanigo <arielrossanigo>`.
 
+- Add :class:`imblearn.over_sampling.BorderlineSMOTE` and
+  :class:`imblearn.over_sampling.SVMSMOTE` in the API documenation.
+  :issue:`530` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Maintenance
 ...........
 


### PR DESCRIPTION
closes #524 