### PR TITLE
FIX: explicit conversion to original sparse format in SMOTENC

### DIFF
--- a/doc/whats_new/v0.5.rst
+++ b/doc/whats_new/v0.5.rst
@@ -31,3 +31,7 @@ Bug
   was moved before the activation function and the bias was removed from the
   dense layer.
   :issue:`531` by :user:`Guillaume Lemaitre <glemaitre>`.
+
+- Fix bug which converting to COO format sparse when stacking the matrices in
+  :class:`imblearn.over_sampling.SMOTENC`. This bug was only old scipy version.
+  :issue:`539` by :user:`Guillaume Lemaitre <glemaitre>`.

--- a/imblearn/over_sampling/_smote.py
+++ b/imblearn/over_sampling/_smote.py
@@ -815,6 +815,8 @@ SMOTE # doctest: +NORMALIZE_WHITESPACE
 
             if sparse.issparse(X_new):
                 X_resampled = sparse.vstack([X_resampled, X_new])
+                sparse_func = 'tocsc' if X.format == 'csc' else 'tocsr'
+                X_resampled = getattr(X_resampled, sparse_func)()
             else:
                 X_resampled = np.vstack((X_resampled, X_new))
             y_resampled = np.hstack((y_resampled, y_new))
@@ -1021,6 +1023,7 @@ class SMOTENC(SMOTE):
         X_ohe.data = (np.ones_like(X_ohe.data, dtype=X_ohe.dtype) *
                       self.median_std_ / 2)
         X_encoded = sparse.hstack((X_continuous, X_ohe), format='csr')
+        print(type(X_encoded))
 
         X_resampled, y_resampled = super(SMOTENC, self)._fit_resample(
             X_encoded, y)

--- a/imblearn/over_sampling/_smote.py
+++ b/imblearn/over_sampling/_smote.py
@@ -1023,8 +1023,7 @@ class SMOTENC(SMOTE):
         X_ohe.data = (np.ones_like(X_ohe.data, dtype=X_ohe.dtype) *
                       self.median_std_ / 2)
         X_encoded = sparse.hstack((X_continuous, X_ohe), format='csr')
-        print(type(X_encoded))
-
+        
         X_resampled, y_resampled = super(SMOTENC, self)._fit_resample(
             X_encoded, y)
 

--- a/imblearn/over_sampling/_smote.py
+++ b/imblearn/over_sampling/_smote.py
@@ -1023,7 +1023,7 @@ class SMOTENC(SMOTE):
         X_ohe.data = (np.ones_like(X_ohe.data, dtype=X_ohe.dtype) *
                       self.median_std_ / 2)
         X_encoded = sparse.hstack((X_continuous, X_ohe), format='csr')
-        
+
         X_resampled, y_resampled = super(SMOTENC, self)._fit_resample(
             X_encoded, y)
 


### PR DESCRIPTION
closes #535 

Fix issue of sparse format conversion in old scipy version.