### PR TITLE
[MRG] vectorize true-class probability calculation of InstanceHardnessThres…

### DIFF
--- a/imblearn/under_sampling/_prototype_selection/_instance_hardness_threshold.py
+++ b/imblearn/under_sampling/_prototype_selection/_instance_hardness_threshold.py
@@ -157,11 +157,7 @@ class InstanceHardnessThreshold(BaseUnderSampler):
             self.estimator_.fit(X_train, y_train)
 
             probs = self.estimator_.predict_proba(X_test)
-            classes = self.estimator_.classes_
-            probabilities[test_index] = [
-                probs[l, np.where(classes == c)[0][0]]
-                for l, c in enumerate(y_test)
-            ]
+            probabilities[test_index] = probs[range(len(y_test)), y_test]
 
         idx_under = np.empty((0, ), dtype=int)
 


### PR DESCRIPTION
Hello, first time contributor here.

I noticed the true-class probability calculation inside `_fit_resample` method of `InstanceHardnessThreshold` was using python `for` loop. This PR vectorizes that.

The change in performance is not significant, since time spent is dominated by training estimator. For a dataset of 1 million synthetic samples, this brings down the time spent for that particular operation from 353 ms to 29 ms in my PC. 

Thank you.