### PR TITLE
More precise set-theoretic language in `under_sampling` doc

### DIFF
--- a/doc/under_sampling.rst
+++ b/doc/under_sampling.rst
@@ -15,7 +15,7 @@ Prototype generation
 ====================
 
 Given an original data set :math:`S`, prototype generation algorithms will
-generate a new set :math:`S'` where :math:`|S'| < |S|` and :math:`S' \not\in
+generate a new set :math:`S'` where :math:`|S'| < |S|` and :math:`S' \not\subset
 S`. In other words, prototype generation technique will reduce the number of
 samples in the targeted classes but the remaining samples are generated --- and
 not selected --- from the original set.


### PR DESCRIPTION
The language in `under_sampling.rst` stated that the synthetic data set was not an _element of_ the real data set. More correctly put, the synthetic data is not a _subset of_ the real data.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
