### PR TITLE
[MRG] 👽 Maintenance for `imblearn.show_versions()`, fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,10 @@ matrix:
     - env: DISTRIB="ubuntu"
     # Latest release
     - env: DISTRIB="conda" PYTHON_VERSION="3.6"
-           NUMPY_VERSION="*" SCIPY_VERSION="*" SKLEARN_VERSION="0.21.3"
+           NUMPY_VERSION="*" SCIPY_VERSION="*" SKLEARN_VERSION="0.21.2"
            OPTIONAL_DEPS="true"
     - env: DISTRIB="conda" PYTHON_VERSION="3.7"
-           NUMPY_VERSION="*" SCIPY_VERSION="*" SKLEARN_VERSION="0.21.3"
+           NUMPY_VERSION="*" SCIPY_VERSION="*" SKLEARN_VERSION="0.21.2"
            OPTIONAL_DEPS="false"
     - env: DISTRIB="conda" PYTHON_VERSION="3.7"
            NUMPY_VERSION="*" SCIPY_VERSION="*" SKLEARN_VERSION="master"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,10 @@ matrix:
     - env: DISTRIB="ubuntu"
     # Latest release
     - env: DISTRIB="conda" PYTHON_VERSION="3.6"
-           NUMPY_VERSION="*" SCIPY_VERSION="*" SKLEARN_VERSION="0.21.2"
+           NUMPY_VERSION="*" SCIPY_VERSION="*" SKLEARN_VERSION="0.21.3"
            OPTIONAL_DEPS="true"
     - env: DISTRIB="conda" PYTHON_VERSION="3.7"
-           NUMPY_VERSION="*" SCIPY_VERSION="*" SKLEARN_VERSION="0.21.2"
+           NUMPY_VERSION="*" SCIPY_VERSION="*" SKLEARN_VERSION="0.21.3"
            OPTIONAL_DEPS="false"
     - env: DISTRIB="conda" PYTHON_VERSION="3.7"
            NUMPY_VERSION="*" SCIPY_VERSION="*" SKLEARN_VERSION="master"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -28,7 +28,11 @@ if [[ "$DISTRIB" == "conda" ]]; then
     MINICONDA_PATH=/home/travis/miniconda
     chmod +x miniconda.sh && ./miniconda.sh -b -p $MINICONDA_PATH
     export PATH=$MINICONDA_PATH/bin:$PATH
-    conda install --yes conda=4.6
+
+    conda config --set always_yes yes --set changeps1 no
+    conda install conda=4.6
+    conda update -q conda
+    conda info -a
 
     # Configure the conda environment and put it in the path using the
     # provided versions

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -28,7 +28,6 @@ if [[ "$DISTRIB" == "conda" ]]; then
     MINICONDA_PATH=/home/travis/miniconda
     chmod +x miniconda.sh && ./miniconda.sh -b -p $MINICONDA_PATH
     export PATH=$MINICONDA_PATH/bin:$PATH
-
     conda config --set always_yes yes --set changeps1 no
     conda install conda=4.6
     conda update -q conda

--- a/imblearn/utils/_show_versions.py
+++ b/imblearn/utils/_show_versions.py
@@ -59,49 +59,36 @@ def show_versions(github=False):
         If true, wrap system info with GitHub markup.
     """
 
-    from sklearn.utils._show_versions import (
-        _get_sys_info,
-        _get_blas_info,
-    )
+    from sklearn.utils._show_versions import _get_sys_info
 
     _sys_info = _get_sys_info()
-    _blas_info = _get_blas_info()
     _deps_info = _get_deps_info()
     _github_markup = (
         "<details>"
-        "<summary>System, BLAS, and Dependencies</summary>\n\n"
+        "<summary>System and Dependency Information</summary>\n\n"
         "**System Information**\n\n"
         "{0}\n"
-        "**BLAS**\n\n"
-        "{1}\n"
         "**Python Dependencies**\n\n"
-        "{2}\n"
+        "{1}\n"
         "</details>"
     )
 
     if github:
 
         _sys_markup = ""
-        _blas_markup = ""
         _deps_markup = ""
 
         for k, stat in _sys_info.items():
             _sys_markup += "* {k:<10}: `{stat}`\n".format(k=k, stat=stat)
-        for k, stat in _blas_info.items():
-            _blas_markup += "* {k:<10}: `{stat}`\n".format(k=k, stat=stat)
         for k, stat in _deps_info.items():
             _deps_markup += "* {k:<10}: `{stat}`\n".format(k=k, stat=stat)
 
-        print(_github_markup.format(_sys_markup, _blas_markup, _deps_markup))
+        print(_github_markup.format(_sys_markup, _deps_markup))
 
     else:
 
         print("\nSystem:")
         for k, stat in _sys_info.items():
-            print("{k:>11}: {stat}".format(k=k, stat=stat))
-
-        print("\nBLAS:")
-        for k, stat in _blas_info.items():
             print("{k:>11}: {stat}".format(k=k, stat=stat))
 
         print("\nPython dependencies:")

--- a/imblearn/utils/_show_versions.py
+++ b/imblearn/utils/_show_versions.py
@@ -65,7 +65,7 @@ def show_versions(github=False):
     _deps_info = _get_deps_info()
     _github_markup = (
         "<details>"
-        "<summary>System and Dependency Information</summary>\n\n"
+        "<summary>System, Dependency Information</summary>\n\n"
         "**System Information**\n\n"
         "{0}\n"
         "**Python Dependencies**\n\n"

--- a/imblearn/utils/tests/test_show_versions.py
+++ b/imblearn/utils/tests/test_show_versions.py
@@ -24,9 +24,6 @@ def test_show_versions_default(capsys):
     assert "python" in out
     assert "executable" in out
     assert "machine" in out
-    assert "macros" in out
-    assert "lib_dirs" in out
-    assert "cblas_libs" in out
     assert "pip" in out
     assert "setuptools" in out
     assert "imblearn" in out
@@ -42,15 +39,11 @@ def test_show_versions_default(capsys):
 def test_show_versions_github(capsys):
     show_versions(github=True)
     out, err = capsys.readouterr()
-    assert "<details><summary>System, BLAS, and Dependencies</summary>" in out
+    assert "<details><summary>System and Dependency Information</summary>" in out
     assert "**System Information**" in out
     assert "* python" in out
     assert "* executable" in out
     assert "* machine" in out
-    assert "**BLAS**" in out
-    assert "* macros" in out
-    assert "* lib_dirs" in out
-    assert "* cblas_libs" in out
     assert "**Python Dependencies**" in out
     assert "* pip" in out
     assert "* setuptools" in out

--- a/imblearn/utils/tests/test_show_versions.py
+++ b/imblearn/utils/tests/test_show_versions.py
@@ -39,7 +39,7 @@ def test_show_versions_default(capsys):
 def test_show_versions_github(capsys):
     show_versions(github=True)
     out, err = capsys.readouterr()
-    assert "<details><summary>System and Dependency Information</summary>" in out
+    assert "<details><summary>System, Dependency Information</summary>" in out
     assert "**System Information**" in out
     assert "* python" in out
     assert "* executable" in out


### PR DESCRIPTION
#### Summary

- Drop `get_blas_info()` vendored from sklearn
- Fix unit tests to reflect the fix

#### What does this implement/fix? Explain your changes.

`imblearn/utils/_show_versions` used several utilities from scikit-learn. BLAS/CBLAS were recently dropped and `get_blas_info()` was removed.

This patch reflects these changes.

#### Any other comments?

See [scikit-learn#14205](https://github.com/scikit-learn/scikit-learn/pull/14205)