### PR TITLE
Fix typos in specificity_score

### DIFF
--- a/imblearn/metrics/_classification.py
+++ b/imblearn/metrics/_classification.py
@@ -370,7 +370,7 @@ def specificity_score(y_true,
 
     The specificity is the ratio ``tn / (tn + fp)`` where ``tn`` is the number
     of true negatives and ``fp`` the number of false positives. The specificity
-    quantifies the ability to avoid false positives_[1].
+    quantifies the ability to avoid false positives.
 
     The best value is 1 and the worst value is 0.
 

--- a/imblearn/metrics/_classification.py
+++ b/imblearn/metrics/_classification.py
@@ -369,7 +369,7 @@ def specificity_score(y_true,
     """Compute the specificity
 
     The specificity is the ratio ``tn / (tn + fp)`` where ``tn`` is the number
-    of true negatives and ``fn`` the number of false negatives. The specificity
+    of true negatives and ``fp`` the number of false positives. The specificity
     quantifies the ability to avoid false positives_[1].
 
     The best value is 1 and the worst value is 0.


### PR DESCRIPTION
#### Summary

Fix typo `fn` -> `fp`
Fix typo "false negatives" -> "false positives"
Fix removing empty reference: `_[1]` -> ` `

#### Reference Issue

- Former issue on this topic: #592
- Fixes #613 

#### What does this implement/fix? Explain your changes.

This fixes the wording in `imblearn.metrics._classification.specificity_score(...)`:

```diff
- ... `fn` the number of false negatives. ...
+ ... `fp` the number of false positives. ...
```

And drops an empty reference:

```diff
- ... false positives_[1].
+ ... false positives.
```

#### Any other comments?

The latest [documentation for specificity score](https://imbalanced-learn.readthedocs.io/en/latest/generated/imblearn.metrics.specificity_score.html) does not seem to currently reflect the recent changes (e.g. #592).

It might be worth checking the sphinx builds on ReadTheDocs, *it's possible that they haven't been deploying recently*.