### PR TITLE
DOC fix spacing issue when using sphinx_rtd_theme

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -313,8 +313,15 @@ issues_github_path = 'scikit-learn-contrib/imbalanced-learn'
 issues_user_uri = 'https://github.com/{user}'
 
 
+# Temporary work-around for spacing problem between parameter and parameter
+# type in the doc, see https://github.com/numpy/numpydoc/issues/215. The bug
+# has been fixed in sphinx (https://github.com/sphinx-doc/sphinx/pull/5976) but
+# through a change in sphinx basic.css except rtd_theme does not use basic.css.
+# In an ideal world, this would get fixed in this PR:
+# https://github.com/readthedocs/sphinx_rtd_theme/pull/747/files
 def setup(app):
     app.add_javascript('js/copybutton.js')
+    app.add_stylesheet("basic.css")
     # app.connect('autodoc-process-docstring', generate_example_rst)
 
 


### PR DESCRIPTION
Some issue with documentation rendering solve in:

https://github.com/readthedocs/sphinx_rtd_theme/issues/766#issuecomment-517145293