### PR TITLE
MNT remove keras and tensorflow from doc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,6 @@ EXTRAS_REQUIRE = {
         'numpydoc',
         'matplotlib',
         'pandas',
-        'keras',
-        'tensorflow>=1.0,<2'
     ]
 }
 


### PR DESCRIPTION
We should remove `keras` and `tensorflow` to be able to build the documentation on `readthedocs`.
We should find another solution later