### PR TITLE
ENH accept non finite values in random samplers

### DIFF
--- a/doc/whats_new/v0.6.rst
+++ b/doc/whats_new/v0.6.rst
@@ -51,6 +51,11 @@ Enhancement
   to check or not the input ``X`` and ``y``.
   :pr:`637` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- :class:`imblearn.under_sampling.RandomUnderSampler`,
+  :class:`imblearn.over_sampling.RandomOverSampler` can resample when non
+  finite values are present in ``X``.
+  :pr:`xxx` by `Guillaume Lemaitre <glemaitre>`.
+
 Deprecation
 ...........
 

--- a/doc/whats_new/v0.6.rst
+++ b/doc/whats_new/v0.6.rst
@@ -54,7 +54,7 @@ Enhancement
 - :class:`imblearn.under_sampling.RandomUnderSampler`,
   :class:`imblearn.over_sampling.RandomOverSampler` can resample when non
   finite values are present in ``X``.
-  :pr:`xxx` by `Guillaume Lemaitre <glemaitre>`.
+  :pr:`643` by `Guillaume Lemaitre <glemaitre>`.
 
 Deprecation
 ...........

--- a/imblearn/over_sampling/_random_over_sampler.py
+++ b/imblearn/over_sampling/_random_over_sampler.py
@@ -109,4 +109,8 @@ RandomOverSampler # doctest: +NORMALIZE_WHITESPACE
         )
 
     def _more_tags(self):
-        return {"X_types": ["2darray", "string"], "sample_indices": True}
+        return {
+            "X_types": ["2darray", "string"],
+            "sample_indices": True,
+            "allow_nan": True,
+        }

--- a/imblearn/over_sampling/_random_over_sampler.py
+++ b/imblearn/over_sampling/_random_over_sampler.py
@@ -79,7 +79,8 @@ RandomOverSampler # doctest: +NORMALIZE_WHITESPACE
         y, binarize_y = check_target_type(y, indicate_one_vs_all=True)
         if not hasattr(X, "loc"):
             # Do not convert dataframe
-            X = check_array(X, accept_sparse=["csr", "csc"], dtype=None)
+            X = check_array(X, accept_sparse=["csr", "csc"], dtype=None,
+                            force_all_finite=False)
         y = check_array(
             y, accept_sparse=["csr", "csc"], dtype=None, ensure_2d=False
         )

--- a/imblearn/over_sampling/tests/test_random_over_sampler.py
+++ b/imblearn/over_sampling/tests/test_random_over_sampler.py
@@ -125,3 +125,23 @@ def test_random_over_sampling_heterogeneous_data():
     assert y_res.shape[0] == 4
     assert X_res.dtype == object
     assert X_res[-1, 0] in X_hetero[:, 0]
+
+
+def test_random_over_sampling_nan_inf():
+    # check that we can oversample even with missing or infinite data
+    # regression tests for #605
+    rng = np.random.RandomState(42)
+    n_not_finite = X.shape[0] // 3
+    row_indices = rng.choice(np.arange(X.shape[0]), size=n_not_finite)
+    col_indices = rng.randint(0, X.shape[1], size=n_not_finite)
+    not_finite_values = rng.choice([np.nan, np.inf], size=n_not_finite)
+
+    X_ = X.copy()
+    X_[row_indices, col_indices] = not_finite_values
+
+    ros = RandomOverSampler(random_state=0)
+    X_res, y_res = ros.fit_resample(X_, Y)
+
+    assert y_res.shape == (14,)
+    assert X_res.shape == (14, 2)
+    assert np.any(~np.isfinite(X_res))

--- a/imblearn/under_sampling/_prototype_selection/_random_under_sampler.py
+++ b/imblearn/under_sampling/_prototype_selection/_random_under_sampler.py
@@ -122,4 +122,8 @@ RandomUnderSampler # doctest: +NORMALIZE_WHITESPACE
         return _safe_indexing(X, idx_under), _safe_indexing(y, idx_under)
 
     def _more_tags(self):
-        return {"X_types": ["2darray", "string"], "sample_indices": True}
+        return {
+            "X_types": ["2darray", "string"],
+            "sample_indices": True,
+            "allow_nan": True,
+        }

--- a/imblearn/under_sampling/_prototype_selection/_random_under_sampler.py
+++ b/imblearn/under_sampling/_prototype_selection/_random_under_sampler.py
@@ -85,7 +85,8 @@ RandomUnderSampler # doctest: +NORMALIZE_WHITESPACE
         y, binarize_y = check_target_type(y, indicate_one_vs_all=True)
         if not hasattr(X, "loc"):
             # Do not convert dataframe
-            X = check_array(X, accept_sparse=["csr", "csc"], dtype=None)
+            X = check_array(X, accept_sparse=["csr", "csc"], dtype=None,
+                            force_all_finite=False)
         y = check_array(
             y, accept_sparse=["csr", "csc"], dtype=None, ensure_2d=False
         )

--- a/imblearn/under_sampling/_prototype_selection/tests/test_random_under_sampler.py
+++ b/imblearn/under_sampling/_prototype_selection/tests/test_random_under_sampler.py
@@ -110,3 +110,23 @@ def test_random_under_sampling_heterogeneous_data():
     assert X_res.shape[0] == 2
     assert y_res.shape[0] == 2
     assert X_res.dtype == object
+
+
+def test_random_under_sampling_nan_inf():
+    # check that we can undersample even with missing or infinite data
+    # regression tests for #605
+    rng = np.random.RandomState(42)
+    n_not_finite = X.shape[0] // 3
+    row_indices = rng.choice(np.arange(X.shape[0]), size=n_not_finite)
+    col_indices = rng.randint(0, X.shape[1], size=n_not_finite)
+    not_finite_values = rng.choice([np.nan, np.inf], size=n_not_finite)
+
+    X_ = X.copy()
+    X_[row_indices, col_indices] = not_finite_values
+
+    rus = RandomUnderSampler(random_state=0)
+    X_res, y_res = rus.fit_resample(X_, Y)
+
+    assert y_res.shape == (6,)
+    assert X_res.shape == (6, 2)
+    assert np.any(~np.isfinite(X_res))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
closes #605 


#### What does this implement/fix? Explain your changes.

Avoir rejecting array if they contain NaN or Inf in Random*Sampler. These samplers do not use the these information to sample therefore this is safe to propagate them.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
