### PR TITLE
[MRG] ENH: RepeatedENN `n_iter_` Attribute

### DIFF
--- a/doc/whats_new/v0.6.rst
+++ b/doc/whats_new/v0.6.rst
@@ -81,7 +81,7 @@ Enhancement
   :class:`imblearn.over_sampling.KMeansSMOTE`,
   :class:`imblearn.over_sampling.SMOTENC` is now vectorize with giving
   an additional speed-up when `X` in sparse.
-  :pr:`596` by :user:`Matt Edding <MattEding>`.
+  :pr:`596` by :user:`Matt Eding <MattEding>`.
 
 Deprecation
 ...........

--- a/imblearn/under_sampling/_prototype_selection/_edited_nearest_neighbours.py
+++ b/imblearn/under_sampling/_prototype_selection/_edited_nearest_neighbours.py
@@ -202,6 +202,11 @@ class RepeatedEditedNearestNeighbours(BaseCleaningSampler):
 
         .. versionadded:: 0.4
 
+    n_iter_ : int
+        Number of iterations run.
+
+        .. versionadded:: 0.6
+
     See Also
     --------
     CondensedNearestNeighbour : Undersample by condensing samples.
@@ -325,6 +330,7 @@ RepeatedEditedNearestNeighbours # doctest : +NORMALIZE_WHITESPACE
                     ]
                 break
 
+        self.n_iter_ = n_iter + 1
         X_resampled, y_resampled = X_, y_
 
         return X_resampled, y_resampled

--- a/imblearn/under_sampling/_prototype_selection/tests/test_repeated_edited_nearest_neighbours.py
+++ b/imblearn/under_sampling/_prototype_selection/tests/test_repeated_edited_nearest_neighbours.py
@@ -182,6 +182,7 @@ def test_renn_fit_resample():
     )
     assert_array_equal(X_resampled, X_gt)
     assert_array_equal(y_resampled, y_gt)
+    assert 0 < renn.n_iter_ <= renn.max_iter
 
 
 def test_renn_fit_resample_mode_object():
@@ -266,6 +267,7 @@ def test_renn_fit_resample_mode_object():
     )
     assert_array_equal(X_resampled, X_gt)
     assert_array_equal(y_resampled, y_gt)
+    assert 0 < renn.n_iter_ <= renn.max_iter
 
 
 def test_renn_fit_resample_mode():
@@ -351,6 +353,7 @@ def test_renn_fit_resample_mode():
     )
     assert_array_equal(X_resampled, X_gt)
     assert_array_equal(y_resampled, y_gt)
+    assert 0 < renn.n_iter_ <= renn.max_iter
 
 
 def test_renn_not_good_object():
@@ -358,3 +361,9 @@ def test_renn_not_good_object():
     renn = RepeatedEditedNearestNeighbours(n_neighbors=nn, kind_sel="mode")
     with pytest.raises(ValueError):
         renn.fit_resample(X, Y)
+
+
+def test_renn_iter_attribute():
+    renn = RepeatedEditedNearestNeighbours(max_iter=1)
+    renn.fit_resample(X, Y)
+    assert renn.n_iter_ == 1

--- a/imblearn/under_sampling/_prototype_selection/tests/test_repeated_edited_nearest_neighbours.py
+++ b/imblearn/under_sampling/_prototype_selection/tests/test_repeated_edited_nearest_neighbours.py
@@ -363,7 +363,14 @@ def test_renn_not_good_object():
         renn.fit_resample(X, Y)
 
 
-def test_renn_iter_attribute():
-    renn = RepeatedEditedNearestNeighbours(max_iter=1)
+@pytest.mark.parametrize(
+    "max_iter, n_iter",
+    [
+        (2, 2),
+        (5, 3),
+    ],
+)
+def test_renn_iter_attribute(max_iter, n_iter):
+    renn = RepeatedEditedNearestNeighbours(max_iter=max_iter)
     renn.fit_resample(X, Y)
-    assert renn.n_iter_ == 1
+    assert renn.n_iter_ == n_iter


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
To mimic Scikit-Learn API of estimators that have a `max_iter` parameter, I have added `n_iter_` as an attribute after fitting. See [KMeans](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.KMeans.html) for such an example.

#### Any other comments?
Fixed typo with my name in What's New v0.6