### PR TITLE
FIX incorporate resampling when computing OOB score in BRF

### DIFF
--- a/doc/whats_new/v0.6.rst
+++ b/doc/whats_new/v0.6.rst
@@ -30,7 +30,7 @@ Bug fixes
 
 - Fix a bug in :class:`imblearn.ensemble.BalancedRandomForestClassifier`
   leading to a wrong computation of the OOB score.
-  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`656` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 Maintenance
 ...........

--- a/doc/whats_new/v0.6.rst
+++ b/doc/whats_new/v0.6.rst
@@ -28,6 +28,10 @@ Bug fixes
   `cross_val_predict` is used to take advantage of the parallelism.
   :pr:`599` by :user:`Shihab Shahriar Khan <Shihab-Shahriar>`.
 
+- Fix a bug in :class:`imblearn.ensemble.BalancedRandomForestClassifier`
+  leading to a wrong computation of the OOB score.
+  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Maintenance
 ...........
 

--- a/imblearn/ensemble/tests/test_forest.py
+++ b/imblearn/ensemble/tests/test_forest.py
@@ -115,7 +115,7 @@ def test_balanced_random_forest_oob(imbalanced_dataset):
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, random_state=42, stratify=y
     )
-    est = BalancedRandomForestClassifier(oob_score=True, random_state=0 )
+    est = BalancedRandomForestClassifier(oob_score=True, random_state=0)
 
     est.fit(X_train, y_train)
     test_score = est.score(X_test, y_test)


### PR DESCRIPTION
closes #655 

Resampling was not taken into account when computing the OOB score. Thus, the results was incorparting in-sample and leading to over-optimistic results.