### PR TITLE
pep8 -> pycodestyle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,8 +108,8 @@ tools:
 
 -  No PEP8 warnings, check with:
 
-        $ pip install pep8
-        $ pep8 path/to/module.py
+        $ pip install pycodestyle
+        $ pycodestyle path/to/module.py
 
 -  AutoPEP8 can help you fix some of the easy redundant errors:
 


### PR DESCRIPTION
Installing and calling pep8 as directed now leads to this warning

```
pep8 has been renamed to pycodestyle (GitHub issue #466)
Use of the pep8 tool will be removed in a future release.
Please install and use `pycodestyle` instead.

$ pip install pycodestyle
$ pycodestyle ...
```

This PR updates the contribution guide to reflect the name change.