### PR TITLE
set allow_nd to True in order to accept dims > 2 when using random undersampling

### DIFF
--- a/imblearn/under_sampling/_prototype_selection/_random_under_sampler.py
+++ b/imblearn/under_sampling/_prototype_selection/_random_under_sampler.py
@@ -83,7 +83,7 @@ RandomUnderSampler # doctest: +NORMALIZE_WHITESPACE
     def _check_X_y(self, X, y):
         y, binarize_y = check_target_type(y, indicate_one_vs_all=True)
         X = check_array(X, accept_sparse=["csr", "csc"], dtype=None,
-                        force_all_finite=False)
+                        force_all_finite=False, allow_nd=True)
         y = check_array(
             y, accept_sparse=["csr", "csc"], dtype=None, ensure_2d=False
         )


### PR DESCRIPTION
I want to use random undersampling when my X data has more than 2 dims. 