### PR TITLE
fix: default parameter value inconsistent from doc

### DIFF
--- a/doc/whats_new/v0.7.rst
+++ b/doc/whats_new/v0.7.rst
@@ -5,3 +5,17 @@ Version 0.7.0 (under development)
 
 Changelog
 ---------
+
+Changed models
+..............
+
+The following models might give some different results due to changes:
+
+- :class:`imblearn.ensemble.BalancedRandomForestClassifier`
+
+Bug fixes
+.........
+
+- Change the default value `min_samples_leaf` to be consistent with
+  scikit-learn.
+  :pr:`711` by :user:`zerolfx <zerolfx>`.

--- a/imblearn/ensemble/_forest.py
+++ b/imblearn/ensemble/_forest.py
@@ -301,7 +301,7 @@ class BalancedRandomForestClassifier(RandomForestClassifier):
         criterion="gini",
         max_depth=None,
         min_samples_split=2,
-        min_samples_leaf=2,
+        min_samples_leaf=1,
         min_weight_fraction_leaf=0.0,
         max_features="auto",
         max_leaf_nodes=None,

--- a/imblearn/ensemble/tests/test_forest.py
+++ b/imblearn/ensemble/tests/test_forest.py
@@ -116,7 +116,8 @@ def test_balanced_random_forest_oob(imbalanced_dataset):
         X, y, random_state=42, stratify=y
     )
     est = BalancedRandomForestClassifier(
-        oob_score=True, random_state=0, n_estimators=1000
+        oob_score=True, random_state=0, n_estimators=1000,
+        min_samples_leaf=2,
     )
 
     est.fit(X_train, y_train)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->

#### What does this implement/fix? Explain your changes.

The default value of `min_samples_leaf` in `BalancedRandomForestClassifier` constructor is 2, but in [doc](https://imbalanced-learn.readthedocs.io/en/stable/generated/imblearn.ensemble.BalancedRandomForestClassifier.html), the default value is 1.

#### Any other comments?

This default value in `RandomForestClassifier`(sklearn) is also 1.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
