### PR TITLE
ENH accept string labels in classifier

### DIFF
--- a/doc/whats_new/v0.7.rst
+++ b/doc/whats_new/v0.7.rst
@@ -26,3 +26,14 @@ Bug fixes
 - Change the default value `min_samples_leaf` to be consistent with
   scikit-learn.
   :pr:`711` by :user:`zerolfx <zerolfx>`.
+
+Enhancements
+............
+
+- The classifier implemented in imbalanced-learn,
+  :class:`imblearn.ensemble.BalancedBaggingClassifier`,
+  :class:`imblearn.ensemble.BalancedRandomForestClassifier`,
+  :class:`imblearn.ensemble.EasyEnsembleClassifier`, and
+  :class:`imblearn.ensemble.RUSBoostClassifier`, accept `sampling_strategy`
+  with the same key than in `y` without the need of encoding `y` in advance.
+  :pr:`718` by :user:`Guillaume Lemaitre <glemaitre>`.

--- a/imblearn/ensemble/_bagging.py
+++ b/imblearn/ensemble/_bagging.py
@@ -15,7 +15,7 @@ from sklearn.tree import DecisionTreeClassifier
 from ..pipeline import Pipeline
 from ..under_sampling import RandomUnderSampler
 from ..under_sampling.base import BaseUnderSampler
-from ..utils import Substitution, check_target_type
+from ..utils import Substitution, check_target_type, check_sampling_strategy
 from ..utils._docstring import _n_jobs_docstring
 from ..utils._docstring import _random_state_docstring
 
@@ -208,6 +208,19 @@ BalancedBaggingClassifier # doctest: +NORMALIZE_WHITESPACE
         self.sampling_strategy = sampling_strategy
         self.replacement = replacement
 
+    def _validate_y(self, y):
+        y_encoded = super()._validate_y(y)
+        if isinstance(self.sampling_strategy, dict):
+            self._sampling_strategy = {
+                np.where(self.classes_ == key)[0][0]: value
+                for key, value in check_sampling_strategy(
+                    self.sampling_strategy, y, 'under-sampling',
+                ).items()
+            }
+        else:
+            self._sampling_strategy = self.sampling_strategy
+        return y_encoded
+
     def _validate_estimator(self, default=DecisionTreeClassifier()):
         """Check the estimator and the n_estimator attribute, set the
         `base_estimator_` attribute."""
@@ -233,7 +246,7 @@ BalancedBaggingClassifier # doctest: +NORMALIZE_WHITESPACE
                 (
                     "sampler",
                     RandomUnderSampler(
-                        sampling_strategy=self.sampling_strategy,
+                        sampling_strategy=self._sampling_strategy,
                         replacement=self.replacement,
                     ),
                 ),

--- a/imblearn/ensemble/_forest.py
+++ b/imblearn/ensemble/_forest.py
@@ -458,7 +458,7 @@ class BalancedRandomForestClassifier(RandomForestClassifier):
 
         self._sampling_strategy = {
             np.where(self.classes_[0] == key)[0][0]: value
-            for key, value in self.sampling_strategy.items()
+            for key, value in self._sampling_strategy.items()
         }
 
         if expanded_class_weight is not None:

--- a/imblearn/ensemble/tests/test_forest.py
+++ b/imblearn/ensemble/tests/test_forest.py
@@ -2,14 +2,12 @@ import pytest
 
 import numpy as np
 
-from sklearn.datasets import fetch_openml
 from sklearn.datasets import make_classification
 from sklearn.model_selection import GridSearchCV
 from sklearn.model_selection import train_test_split
 from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_array_equal
 
-from imblearn.datasets import make_imbalance
 from imblearn.ensemble import BalancedRandomForestClassifier
 
 

--- a/imblearn/ensemble/tests/test_forest.py
+++ b/imblearn/ensemble/tests/test_forest.py
@@ -2,12 +2,14 @@ import pytest
 
 import numpy as np
 
+from sklearn.datasets import fetch_openml
 from sklearn.datasets import make_classification
 from sklearn.model_selection import GridSearchCV
 from sklearn.model_selection import train_test_split
 from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_array_equal
 
+from imblearn.datasets import make_imbalance
 from imblearn.ensemble import BalancedRandomForestClassifier
 
 
@@ -198,3 +200,20 @@ def test_balanced_random_forest_oob_binomial(ratio):
     erf = BalancedRandomForestClassifier(oob_score=True, random_state=42)
     erf.fit(X, y)
     assert np.abs(erf.oob_score_ - 0.5) < 0.1
+
+
+def test_balanced_random_forest_str_labels():
+    # Non-regression test for #709
+    # https://github.com/scikit-learn-contrib/imbalanced-learn/issues/709
+    df, y = fetch_openml("iris", version=1, as_frame=True, return_X_y=True)
+    df, y = make_imbalance(
+        df, y, sampling_strategy={
+            "Iris-setosa": 30, "Iris-versicolor": 20, "Iris-virginica": 50
+        }
+    )
+    forest = BalancedRandomForestClassifier(
+        sampling_strategy={
+            "Iris-setosa": 20, "Iris-versicolor": 20, "Iris-virginica": 20
+        }
+    )
+    forest.fit(df, y)

--- a/imblearn/ensemble/tests/test_forest.py
+++ b/imblearn/ensemble/tests/test_forest.py
@@ -200,20 +200,3 @@ def test_balanced_random_forest_oob_binomial(ratio):
     erf = BalancedRandomForestClassifier(oob_score=True, random_state=42)
     erf.fit(X, y)
     assert np.abs(erf.oob_score_ - 0.5) < 0.1
-
-
-def test_balanced_random_forest_str_labels():
-    # Non-regression test for #709
-    # https://github.com/scikit-learn-contrib/imbalanced-learn/issues/709
-    df, y = fetch_openml("iris", version=1, as_frame=True, return_X_y=True)
-    df, y = make_imbalance(
-        df, y, sampling_strategy={
-            "Iris-setosa": 30, "Iris-versicolor": 20, "Iris-virginica": 50
-        }
-    )
-    forest = BalancedRandomForestClassifier(
-        sampling_strategy={
-            "Iris-setosa": 20, "Iris-versicolor": 20, "Iris-virginica": 20
-        }
-    )
-    forest.fit(df, y)

--- a/imblearn/utils/_validation.py
+++ b/imblearn/utils/_validation.py
@@ -28,7 +28,7 @@ TARGET_KIND = ("binary", "multiclass", "multilabel-indicator")
 
 
 class ArraysTransformer:
-    """A class to convert sampler ouput arrays to their orinal types."""
+    """A class to convert sampler output arrays to their original types."""
 
     def __init__(self, X, y):
         self.x_props = self._gets_props(X)

--- a/imblearn/utils/estimator_checks.py
+++ b/imblearn/utils/estimator_checks.py
@@ -384,6 +384,7 @@ def check_classifier_on_multilabel_or_multioutput_targets(name, estimator):
 def check_classifiers_with_encoded_labels(name, classifier):
     # Non-regression test for #709
     # https://github.com/scikit-learn-contrib/imbalanced-learn/issues/709
+    pytest.importorskip("pandas")
     df, y = fetch_openml("iris", version=1, as_frame=True, return_X_y=True)
     df, y = make_imbalance(
         df, y, sampling_strategy={

--- a/imblearn/utils/estimator_checks.py
+++ b/imblearn/utils/estimator_checks.py
@@ -17,7 +17,9 @@ import numpy as np
 from scipy import sparse
 
 from sklearn.base import clone
+from sklearn.base import is_classifier
 from sklearn.datasets import (
+    fetch_openml,
     make_classification,
     make_multilabel_classification,
 )  # noqa
@@ -30,6 +32,7 @@ from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_raises_regex
 from sklearn.utils.multiclass import type_of_target
 
+from imblearn.datasets import make_imbalance
 from imblearn.over_sampling.base import BaseOverSampler
 from imblearn.under_sampling.base import BaseCleaningSampler, BaseUnderSampler
 
@@ -65,6 +68,7 @@ def _yield_sampler_checks(sampler):
 
 def _yield_classifier_checks(classifier):
     yield check_classifier_on_multilabel_or_multioutput_targets
+    yield check_classifiers_with_encoded_labels
 
 
 def _yield_all_checks(estimator):
@@ -376,3 +380,23 @@ def check_classifier_on_multilabel_or_multioutput_targets(name, estimator):
     msg = "Multilabel and multioutput targets are not supported."
     with pytest.raises(ValueError, match=msg):
         estimator.fit(X, y)
+
+
+def check_classifiers_with_encoded_labels(name, classifier):
+    # Non-regression test for #709
+    # https://github.com/scikit-learn-contrib/imbalanced-learn/issues/709
+    df, y = fetch_openml("iris", version=1, as_frame=True, return_X_y=True)
+    df, y = make_imbalance(
+        df, y, sampling_strategy={
+            "Iris-setosa": 30, "Iris-versicolor": 20, "Iris-virginica": 50,
+        }
+    )
+    classifier.set_params(
+        sampling_strategy={
+            "Iris-setosa": 20, "Iris-virginica": 20,
+        }
+    )
+    classifier.fit(df, y)
+    assert set(classifier.classes_) == set(y.cat.categories.tolist())
+    y_pred = classifier.predict(df)
+    assert set(y_pred) == set(y.cat.categories.tolist())

--- a/imblearn/utils/estimator_checks.py
+++ b/imblearn/utils/estimator_checks.py
@@ -17,7 +17,6 @@ import numpy as np
 from scipy import sparse
 
 from sklearn.base import clone
-from sklearn.base import is_classifier
 from sklearn.datasets import (
     fetch_openml,
     make_classification,


### PR DESCRIPTION
closes #709 

Allow to pass the original `y` values without to encode the labels before hand.