### PR TITLE
ENH make lazy import of the keras module when importing imblearn

### DIFF
--- a/doc/whats_new/v0.7.rst
+++ b/doc/whats_new/v0.7.rst
@@ -37,3 +37,7 @@ Enhancements
   :class:`imblearn.ensemble.RUSBoostClassifier`, accept `sampling_strategy`
   with the same key than in `y` without the need of encoding `y` in advance.
   :pr:`718` by :user:`Guillaume Lemaitre <glemaitre>`.
+
+- Lazy import `keras` module when importing `imblearn.
+  :pr:`719` by :user:`Guillaume Lemaitre <glemaitre>`.
+

--- a/imblearn/__init__.py
+++ b/imblearn/__init__.py
@@ -31,10 +31,13 @@ utils
 pipeline
     Module which allowing to create pipeline with scikit-learn estimators.
 """
+import importlib
+import sys
+import types
+
 from . import combine
 from . import ensemble
 from . import exceptions
-from . import keras
 from . import metrics
 from . import over_sampling
 from . import tensorflow
@@ -45,6 +48,50 @@ from . import pipeline
 from .base import FunctionSampler
 from ._version import __version__
 from .utils._show_versions import show_versions
+
+
+# # FIXME: When we get Python 3.7 as minimal version, we will need to switch to
+# # the following solution:
+# # https://snarky.ca/lazy-importing-in-python-3-7/
+class LazyLoader(types.ModuleType):
+    """Lazily import a module, mainly to avoid pulling in large dependencies.
+
+    Adapted from TensorFlow:
+    https://github.com/tensorflow/tensorflow/blob/master/tensorflow/
+    python/util/lazy_loader.py
+    """
+    def __init__(self, local_name, parent_module_globals, name, warning=None):
+        self._local_name = local_name
+        self._parent_module_globals = parent_module_globals
+        self._warning = warning
+
+        super(LazyLoader, self).__init__(name)
+
+    def _load(self):
+        """Load the module and insert it into the parent's globals."""
+        # Import the target module and insert it into the parent's namespace
+        module = importlib.import_module(self.__name__)
+        self._parent_module_globals[self._local_name] = module
+
+        # Update this object's dict so that if someone keeps a reference to the
+        #   LazyLoader, lookups are efficient (__getattr__ is only called on
+        #   lookups that fail).
+        self.__dict__.update(module.__dict__)
+
+        return module
+
+    def __getattr__(self, item):
+        module = self._load()
+        return getattr(module, item)
+
+    def __dir__(self):
+        module = self._load()
+        return dir(module)
+
+
+# delay the import of keras since we are going to import either tensorflow
+# or keras
+keras = LazyLoader("keras", globals(), "imblearn.keras")
 
 __all__ = [
     "combine",

--- a/imblearn/__init__.py
+++ b/imblearn/__init__.py
@@ -32,7 +32,6 @@ pipeline
     Module which allowing to create pipeline with scikit-learn estimators.
 """
 import importlib
-import sys
 import types
 
 from . import combine


### PR DESCRIPTION
closes #704

Lazy import of keras when importing `imblearn`.