### PR TITLE
Fix: Found array with 0 sample(s)

### DIFF
--- a/imblearn/over_sampling/_smote.py
+++ b/imblearn/over_sampling/_smote.py
@@ -554,12 +554,19 @@ SVMSMOTE # doctest: +NORMALIZE_WHITESPACE
             support_vector = _safe_indexing(X, support_index)
 
             self.nn_m_.fit(X)
+            
+            prev_support_vector = support_vector
+            
             noise_bool = self._in_danger_noise(
                 self.nn_m_, support_vector, class_sample, y, kind="noise"
             )
             support_vector = _safe_indexing(
                 support_vector, np.flatnonzero(np.logical_not(noise_bool))
             )
+            
+            if len(support_vector) == 0:
+                support_vector = prev_support_vector
+            
             danger_bool = self._in_danger_noise(
                 self.nn_m_, support_vector, class_sample, y, kind="danger"
             )


### PR DESCRIPTION
Symptom: 
When using SVMSMOTE on dataset which contains a minority class which has very few samples (may be < 10), it'll raise error `ValueError: Found array with 0 sample(s) (shape=(0, 600)) while a minimum of 1 is required.`



<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
#742


#### What does this implement/fix? Explain your changes.
Root cause:
The line `noise_bool = self._in_danger_noise(...)` will find noise data according to `kneighbors` estimator's `n_neighbors` attribute, this value is equal to  `m_neighbors` attribute of `SVMSMOTE` class. If we set a very large number to `m_neighbors` to initialize `SVMSMOTE`, for example: `SVMSMOTE(m_neighbors=1000)`, this error will be gone. This is because the range of neighbor searches is large enough to contain another minority class data point, therefore the center data point will not be treated as noise according to this line `n_maj == nn_estimator.n_neighbors - 1`. But when `m_neighbors` is small (default is 10), and the minority class has very few sample, it may treat whole  minority class data as noise data, cause returned `noise_bool` with all true, then in _safe_indexing(...) will remove all these data, resulted in zero number of support_vector data.

Solution: 
Save `support vector` before trimming noise data point. When after trimmed noise data, check whether the length of support vector is zero, if true, then restore previous saved `support vector`, this enforce every minority data point used as `support_vector`.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
