### PR TITLE
Switch to parse_version() of scikit-learn >= 0.23.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ The dependency requirements are based on the last scikit-learn release:
 
 * scipy(>=0.19.1)
 * numpy(>=1.13.3)
-* scikit-learn(>=0.23)
+* scikit-learn(>=0.23.2)
 * joblib(>=0.11)
 * keras 2 (optional)
 * tensorflow (optional)

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -10,7 +10,7 @@ The imbalanced-learn package requires the following dependencies:
 * python (>=3.6)
 * numpy (>=1.13.3)
 * scipy (>=0.19.1)
-* scikit-learn (>=0.23)
+* scikit-learn (>=0.23.2)
 * keras 2 (optional)
 * tensorflow (optional)
 

--- a/imblearn/metrics/tests/test_classification.py
+++ b/imblearn/metrics/tests/test_classification.py
@@ -14,7 +14,7 @@ from sklearn import datasets
 from sklearn import svm
 
 from sklearn.preprocessing import label_binarize
-from sklearn.utils.fixes import np_version
+from sklearn.utils.fixes import np_version, parse_version
 from sklearn.utils.validation import check_random_state
 from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_array_equal
@@ -413,7 +413,7 @@ def test_classification_report_imbalanced_multiclass_with_unicode_label():
         "red¢ 0.42 0.90 0.55 0.57 0.70 0.51 20 avg / total "
         "0.51 0.53 0.80 0.47 0.58 0.40 75"
     )
-    if np_version[:3] < (1, 7, 0):
+    if np_version < parse_version('1.7.0'):
         with pytest.raises(RuntimeError, match="NumPy < 1.7.0"):
             classification_report_imbalanced(y_true, y_pred)
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.11
 scipy>=0.17
-scikit-learn>=0.23
+scikit-learn>=0.23.2
 joblib>=0.11

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ CLASSIFIERS = ['Intended Audience :: Science/Research',
 INSTALL_REQUIRES = [
     'numpy>=1.13.3',
     'scipy>=0.19.1',
-    'scikit-learn>=0.23',
+    'scikit-learn>=0.23.2',
     'joblib>=0.11'
 ]
 EXTRAS_REQUIRE = {


### PR DESCRIPTION
Closes: #746

Switch to the new parse_version() implementation of `scikit-learn 0.23.2`, and bump the dependencies.