### PR TITLE
FIX select sample from the targeted class in ClusterCentroids

### DIFF
--- a/doc/whats_new/v0.7.rst
+++ b/doc/whats_new/v0.7.rst
@@ -52,7 +52,7 @@ Bug fixes
 - Fix a bug in :class:`imblearn.under_sampling.ClusterCentroids` where
   `voting="hard"` could have lead to select a sample from any class instead of
   the targeted class.
-  :pr:`xx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`769` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 Enhancements
 ............

--- a/doc/whats_new/v0.7.rst
+++ b/doc/whats_new/v0.7.rst
@@ -49,6 +49,11 @@ Bug fixes
   :class:`imblearn.over_sampling.SMOTENC`.
   :pr:`675` by :user:`bganglia <bganglia>`.
 
+- Fix a bug in :class:`imblearn.under_sampling.ClusterCentroids` where
+  `voting="hard"` could have lead to select a sample from any class instead of
+  the targeted class.
+  :pr:`xx` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Enhancements
 ............
 

--- a/imblearn/under_sampling/_prototype_generation/_cluster_centroids.py
+++ b/imblearn/under_sampling/_prototype_generation/_cluster_centroids.py
@@ -166,17 +166,20 @@ ClusterCentroids # doctest: +NORMALIZE_WHITESPACE
 
         X_resampled, y_resampled = [], []
         for target_class in np.unique(y):
+            target_class_indices = np.flatnonzero(y == target_class)
             if target_class in self.sampling_strategy_.keys():
                 n_samples = self.sampling_strategy_[target_class]
                 self.estimator_.set_params(**{"n_clusters": n_samples})
-                self.estimator_.fit(X[y == target_class])
+                self.estimator_.fit(_safe_indexing(X, target_class_indices))
                 X_new, y_new = self._generate_sample(
-                    X, y, self.estimator_.cluster_centers_, target_class
+                    _safe_indexing(X, target_class_indices),
+                    _safe_indexing(y, target_class_indices),
+                    self.estimator_.cluster_centers_,
+                    target_class,
                 )
                 X_resampled.append(X_new)
                 y_resampled.append(y_new)
             else:
-                target_class_indices = np.flatnonzero(y == target_class)
                 X_resampled.append(_safe_indexing(X, target_class_indices))
                 y_resampled.append(_safe_indexing(y, target_class_indices))
 


### PR DESCRIPTION
closes #741
closes #738 

When `voting="hard"` any sample from `X` could have been selected instead of a sample from `X[target_class]`.