### PR TITLE
FEA Add macro-averaged mean absolute error

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -215,8 +215,8 @@ Imbalance-learn provides some fast-prototyping tools.
    metrics.sensitivity_score
    metrics.specificity_score
    metrics.geometric_mean_score
-   metrics.make_index_balanced_accuracy
    metrics.macro_averaged_mean_absolute_error
+   metrics.make_index_balanced_accuracy
 
 .. _datasets_ref:
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -216,6 +216,7 @@ Imbalance-learn provides some fast-prototyping tools.
    metrics.specificity_score
    metrics.geometric_mean_score
    metrics.make_index_balanced_accuracy
+   metrics.macro_averaged_mean_absolute_error
 
 .. _datasets_ref:
 

--- a/doc/bibtex/refs.bib
+++ b/doc/bibtex/refs.bib
@@ -208,3 +208,19 @@
   url = {https://doi.org/10.1007/s10618-012-0295-5},
   doi = {10.1007/s10618-012-0295-5}
 }
+
+@article{esuli2009ordinal,
+  author = {A. Esuli and S. Baccianella and F. Sebastiani},
+  title = {Evaluation Measures for Ordinal Regression},
+  journal = {Intelligent Systems Design and Applications, International Conference on},
+  year = {2009},
+  volume = {1},
+  issn = {},
+  pages = {283-287},
+  keywords = {ordinal regression;ordinal classification;evaluation measures;class imbalance;product reviews},
+  doi = {10.1109/ISDA.2009.230},
+  url = {https://doi.ieeecomputersociety.org/10.1109/ISDA.2009.230},
+  publisher = {IEEE Computer Society},
+  address = {Los Alamitos, CA, USA},
+  month = {dec}
+}

--- a/doc/metrics.rst
+++ b/doc/metrics.rst
@@ -54,3 +54,10 @@ The :func:`classification_report_imbalanced` will compute a set of metrics
 per class and summarize it in a table. The parameter `output_dict` allows
 to get a string or a Python dictionary. This dictionary can be reused to create
 a Pandas dataframe for instance.
+
+.. _macro_averaged_mean_absolute_error:
+
+Macro-Averaged Mean Absolute Error (MA-MAE)
+-------------------------------------------
+
+The :func:`macro_averaged_mean_absolute_error` :cite:`esuli2009ordinal` is used for imbalanced ordinal classification. We compute each MAE for each class and average them, giving an equal weight to each class.

--- a/doc/metrics.rst
+++ b/doc/metrics.rst
@@ -54,8 +54,8 @@ Ordinal classification is used when there is a rank among classes, for example
 levels of functionality or movie ratings.
 
 The :func:`macro_averaged_mean_absolute_error` :cite:`esuli2009ordinal` is used
-for imbalanced ordinal classification. We compute each MAE for each class and
-average them, giving an equal weight to each class.
+for imbalanced ordinal classification. The mean absolute error is computed for
+each class and averaged over classes, giving an equal weight to each class.
 
 .. _classification_report:
 

--- a/doc/metrics.rst
+++ b/doc/metrics.rst
@@ -45,6 +45,18 @@ The :func:`make_index_balanced_accuracy` :cite:`garcia2012effectiveness` can
 wrap any metric and give more importance to a specific class using the
 parameter ``alpha``.
 
+.. _macro_averaged_mean_absolute_error:
+
+Macro-Averaged Mean Absolute Error (MA-MAE)
+-------------------------------------------
+
+Ordinal classification is used when there is a rank among classes, for example
+levels of functionality or movie ratings.
+
+The :func:`macro_averaged_mean_absolute_error` :cite:`esuli2009ordinal` is used
+for imbalanced ordinal classification. We compute each MAE for each class and
+average them, giving an equal weight to each class.
+
 .. _classification_report:
 
 Summary of important metrics
@@ -54,10 +66,3 @@ The :func:`classification_report_imbalanced` will compute a set of metrics
 per class and summarize it in a table. The parameter `output_dict` allows
 to get a string or a Python dictionary. This dictionary can be reused to create
 a Pandas dataframe for instance.
-
-.. _macro_averaged_mean_absolute_error:
-
-Macro-Averaged Mean Absolute Error (MA-MAE)
--------------------------------------------
-
-The :func:`macro_averaged_mean_absolute_error` :cite:`esuli2009ordinal` is used for imbalanced ordinal classification. We compute each MAE for each class and average them, giving an equal weight to each class.

--- a/doc/whats_new/v0.7.rst
+++ b/doc/whats_new/v0.7.rst
@@ -76,6 +76,12 @@ Enhancements
   dictionary instead of a string.
   :pr:`770` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- Add the the function
+  :func:`imblearn.metrics.macro_averaged_mean_absolute_error` returning the
+  average across class of the MAE. This metric is used in ordinal
+  classification.
+  :pr:`780` by :user:`Aurélien Massiot <AurelienMassiot>`.
+
 Deprecation
 ...........
 

--- a/imblearn/metrics/__init__.py
+++ b/imblearn/metrics/__init__.py
@@ -18,5 +18,5 @@ __all__ = [
     "geometric_mean_score",
     "make_index_balanced_accuracy",
     "classification_report_imbalanced",
-    "macro_averaged_mean_absolute_error"
+    "macro_averaged_mean_absolute_error",
 ]

--- a/imblearn/metrics/__init__.py
+++ b/imblearn/metrics/__init__.py
@@ -9,6 +9,7 @@ from ._classification import specificity_score
 from ._classification import geometric_mean_score
 from ._classification import make_index_balanced_accuracy
 from ._classification import classification_report_imbalanced
+from ._classification import macro_averaged_mean_absolute_error
 
 __all__ = [
     "sensitivity_specificity_support",
@@ -17,4 +18,5 @@ __all__ = [
     "geometric_mean_score",
     "make_index_balanced_accuracy",
     "classification_report_imbalanced",
+    "macro_averaged_mean_absolute_error"
 ]

--- a/imblearn/metrics/_classification.py
+++ b/imblearn/metrics/_classification.py
@@ -18,6 +18,7 @@ import warnings
 import numpy as np
 import scipy as sp
 
+from sklearn.metrics import mean_absolute_error
 from sklearn.metrics import precision_recall_fscore_support
 from sklearn.metrics._classification import _check_targets
 from sklearn.metrics._classification import _prf_divide
@@ -997,3 +998,53 @@ def classification_report_imbalanced(
     if output_dict:
         return report_dict
     return report
+
+
+@_deprecate_positional_args
+def macro_averaged_mean_absolute_error(y_true, y_pred):
+    """Compute Macro-Averaged Mean Absolute Error (MA-MAE) for imbalanced ordinal classification.
+
+    This function computes each MAE for each class and average them, giving an equal weight to each class.
+
+    Read more in the :ref:`User Guide <macro_averaged_mean_absolute_error>`.
+
+    Parameters
+    ----------
+    y_true : 1d array-like, or label indicator array / sparse matrix
+        Ground truth (correct) target values.
+
+    y_pred : 1d array-like, or label indicator array / sparse matrix
+        Estimated targets as returned by a classifier.
+
+    Returns
+    -------
+    loss : float or ndarray of floats
+        Macro-Avaeraged MAE output is non-negative floating point. The best value is 0.0.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.metrics import mean_absolute_error
+    >>> from imblearn.metrics import macro_averaged_mean_absolute_error
+    >>> y_true_balanced = [1, 1, 1, 2, 2, 2]
+    >>> y_true_imbalanced = [1, 1, 1, 1, 1, 2]
+    >>> y_pred = [1, 2, 1, 2, 1, 2]
+    >>> mean_absolute_error(y_true_balanced, y_pred)
+       0.3333333333333333
+    >>> mean_absolute_error(y_true_imbalanced, y_pred)
+       0.3333333333333333
+    >>> macro_averaged_mean_absolute_error(y_true_balanced, y_pred)
+       0.3333333333333333
+    >>> macro_averaged_mean_absolute_error(y_true_imbalanced, y_pred)
+       0.2
+
+    """
+    all_mae = []
+    y_true = np.array(y_true)
+    y_pred = np.array(y_pred)
+    for class_to_predict in np.unique(y_true):
+        index_class_to_predict = np.where(y_true == class_to_predict)[0]
+        mae_class = mean_absolute_error(y_true[index_class_to_predict], y_pred[index_class_to_predict])
+        all_mae.append(mae_class)
+    ma_mae = sum(all_mae) / len(all_mae)
+    return ma_mae

--- a/imblearn/metrics/_classification.py
+++ b/imblearn/metrics/_classification.py
@@ -1012,10 +1012,10 @@ def macro_averaged_mean_absolute_error(y_true, y_pred):
 
     Parameters
     ----------
-    y_true : 1d array-like, or label indicator array / sparse matrix
+    y_true : array-like of shape (n_samples,) or (n_samples, n_outputs)
         Ground truth (correct) target values.
 
-    y_pred : 1d array-like, or label indicator array / sparse matrix
+    y_pred : array-like of shape (n_samples,) or (n_samples, n_outputs)
         Estimated targets as returned by a classifier.
 
     Returns
@@ -1033,20 +1033,19 @@ def macro_averaged_mean_absolute_error(y_true, y_pred):
     >>> y_true_imbalanced = [1, 2, 2, 2]
     >>> y_pred = [1, 2, 1, 2]
     >>> mean_absolute_error(y_true_balanced, y_pred)
-       0.5
+    0.5
     >>> mean_absolute_error(y_true_imbalanced, y_pred)
-       0.25
+    0.25
     >>> macro_averaged_mean_absolute_error(y_true_balanced, y_pred)
-       0.5
+    0.5
     >>> macro_averaged_mean_absolute_error(y_true_imbalanced, y_pred)
-       0.16666666666666666
+    0.16666666666666666
 
     """
     all_mae = []
-    y_true = np.array(y_true)
-    y_pred = np.array(y_pred)
+    y_true, y_pred = np.asarray(y_true), np.asarray(y_pred)
     for class_to_predict in np.unique(y_true):
-        index_class_to_predict = np.where(y_true == class_to_predict)[0]
+        index_class_to_predict = np.flatnonzero(y_true == class_to_predict)
         mae_class = mean_absolute_error(y_true[index_class_to_predict],
                                         y_pred[index_class_to_predict])
         all_mae.append(mae_class)

--- a/imblearn/metrics/_classification.py
+++ b/imblearn/metrics/_classification.py
@@ -1032,13 +1032,15 @@ def macro_averaged_mean_absolute_error(y_true, y_pred):
     >>> y_true_balanced = [1, 1, 1, 2, 2, 2]
     >>> y_true_imbalanced = [1, 1, 1, 1, 1, 2]
     >>> y_pred = [1, 2, 1, 2, 1, 2]
-    >>> mean_absolute_error(y_true_balanced, y_pred)
-       0.3333333333333333
-    >>> mean_absolute_error(y_true_imbalanced, y_pred)
-       0.3333333333333333
-    >>> macro_averaged_mean_absolute_error(y_true_balanced, y_pred)
-       0.3333333333333333
-    >>> macro_averaged_mean_absolute_error(y_true_imbalanced, y_pred)
+    >>> np.round(mean_absolute_error(y_true_balanced, y_pred), 4)
+       0.3333
+    >>> np.round(mean_absolute_error(y_true_imbalanced, y_pred), 4)
+       0.3333
+    >>> np.round(macro_averaged_mean_absolute_error(y_true_balanced, y_pred),
+                                                    4)
+       0.3333
+    >>> np.round(macro_averaged_mean_absolute_error(y_true_imbalanced, y_pred,
+                                                    4)
        0.2
 
     """

--- a/imblearn/metrics/_classification.py
+++ b/imblearn/metrics/_classification.py
@@ -1002,9 +1002,11 @@ def classification_report_imbalanced(
 
 @_deprecate_positional_args
 def macro_averaged_mean_absolute_error(y_true, y_pred):
-    """Compute Macro-Averaged Mean Absolute Error (MA-MAE) for imbalanced ordinal classification.
+    """Compute Macro-Averaged Mean Absolute Error (MA-MAE)
+    for imbalanced ordinal classification.
 
-    This function computes each MAE for each class and average them, giving an equal weight to each class.
+    This function computes each MAE for each class and average them,
+    giving an equal weight to each class.
 
     Read more in the :ref:`User Guide <macro_averaged_mean_absolute_error>`.
 
@@ -1019,7 +1021,8 @@ def macro_averaged_mean_absolute_error(y_true, y_pred):
     Returns
     -------
     loss : float or ndarray of floats
-        Macro-Avaeraged MAE output is non-negative floating point. The best value is 0.0.
+        Macro-Averaged MAE output is non-negative floating point.
+        The best value is 0.0.
 
     Examples
     --------
@@ -1044,7 +1047,8 @@ def macro_averaged_mean_absolute_error(y_true, y_pred):
     y_pred = np.array(y_pred)
     for class_to_predict in np.unique(y_true):
         index_class_to_predict = np.where(y_true == class_to_predict)[0]
-        mae_class = mean_absolute_error(y_true[index_class_to_predict], y_pred[index_class_to_predict])
+        mae_class = mean_absolute_error(y_true[index_class_to_predict],
+                                        y_pred[index_class_to_predict])
         all_mae.append(mae_class)
     ma_mae = sum(all_mae) / len(all_mae)
     return ma_mae

--- a/imblearn/metrics/_classification.py
+++ b/imblearn/metrics/_classification.py
@@ -1029,19 +1029,18 @@ def macro_averaged_mean_absolute_error(y_true, y_pred):
     >>> import numpy as np
     >>> from sklearn.metrics import mean_absolute_error
     >>> from imblearn.metrics import macro_averaged_mean_absolute_error
-    >>> y_true_balanced = [1, 1, 1, 2, 2, 2]
-    >>> y_true_imbalanced = [1, 1, 1, 1, 1, 2]
-    >>> y_pred = [1, 2, 1, 2, 1, 2]
-    >>> np.round(mean_absolute_error(y_true_balanced, y_pred), 4)
-       0.3333
-    >>> np.round(mean_absolute_error(y_true_imbalanced, y_pred), 4)
-       0.3333
-    >>> np.round(macro_averaged_mean_absolute_error(y_true_balanced, y_pred),
-                                                    4)
-       0.3333
+    >>> y_true_balanced = [1, 1, 2, 2]
+    >>> y_true_imbalanced = [1, 2, 2, 2]
+    >>> y_pred = [1, 2, 1, 2]
+    >>> mean_absolute_error(y_true_balanced, y_pred)
+       0.5
+    >>> mean_absolute_error(y_true_imbalanced, y_pred)
+       0.25
+    >>> macro_averaged_mean_absolute_error(y_true_balanced, y_pred)
+       0.5
     >>> np.round(macro_averaged_mean_absolute_error(y_true_imbalanced, y_pred,
                                                     4)
-       0.2
+       0.1667
 
     """
     all_mae = []

--- a/imblearn/metrics/_classification.py
+++ b/imblearn/metrics/_classification.py
@@ -1038,9 +1038,8 @@ def macro_averaged_mean_absolute_error(y_true, y_pred):
        0.25
     >>> macro_averaged_mean_absolute_error(y_true_balanced, y_pred)
        0.5
-    >>> np.round(macro_averaged_mean_absolute_error(y_true_imbalanced, y_pred,
-                                                    4)
-       0.1667
+    >>> macro_averaged_mean_absolute_error(y_true_imbalanced, y_pred)
+       0.16666666666666666
 
     """
     all_mae = []

--- a/imblearn/metrics/tests/test_classification.py
+++ b/imblearn/metrics/tests/test_classification.py
@@ -29,6 +29,7 @@ from imblearn.metrics import specificity_score
 from imblearn.metrics import geometric_mean_score
 from imblearn.metrics import make_index_balanced_accuracy
 from imblearn.metrics import classification_report_imbalanced
+from imblearn.metrics import macro_averaged_mean_absolute_error
 
 from imblearn.utils.testing import warns
 
@@ -498,3 +499,18 @@ def test_classification_report_imbalanced_dict():
 
     assert outer_keys == expected_outer_keys
     assert inner_keys == expected_inner_keys
+
+
+@pytest.mark.parametrize(
+    "y_true, y_pred, expected_ma_mae",
+    [
+        ([1, 1, 1, 2, 2, 2], [1, 2, 1, 2, 1, 2], 0.333),
+        ([1, 1, 1, 1, 1, 2], [1, 2, 1, 2, 1, 2], 0.2),
+        ([1, 1, 1, 2, 2, 2, 3, 3, 3], [1, 3, 1, 2, 1, 1, 2, 3, 3], 0.555),
+        ([1, 1, 1, 1, 1, 1, 2, 3, 3], [1, 3, 1, 2, 1, 1, 2, 3, 3], 0.166),
+
+    ],
+)
+def test_macro_averaged_mean_absolute_error(y_true, y_pred, expected_ma_mae):
+    ma_mae = macro_averaged_mean_absolute_error(y_true, y_pred)
+    assert ma_mae == pytest.approx(expected_ma_mae, rel=R_TOL)

--- a/imblearn/metrics/tests/test_classification.py
+++ b/imblearn/metrics/tests/test_classification.py
@@ -514,3 +514,17 @@ def test_classification_report_imbalanced_dict():
 def test_macro_averaged_mean_absolute_error(y_true, y_pred, expected_ma_mae):
     ma_mae = macro_averaged_mean_absolute_error(y_true, y_pred)
     assert ma_mae == pytest.approx(expected_ma_mae, rel=R_TOL)
+
+
+def test_macro_averaged_mean_absolute_error_sample_weight():
+    y_true = [1, 1, 1, 2, 2, 2]
+    y_pred = [1, 2, 1, 2, 1, 2]
+
+    ma_mae_no_weights = macro_averaged_mean_absolute_error(y_true, y_pred)
+
+    sample_weight = [1, 1, 1, 1, 1, 1]
+    ma_mae_unit_weights = macro_averaged_mean_absolute_error(
+        y_true, y_pred, sample_weight=sample_weight,
+    )
+
+    assert ma_mae_unit_weights == pytest.approx(ma_mae_no_weights)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


As detailed in the [issue #18901](https://github.com/scikit-learn/scikit-learn/issues/18901) I wrote in Scikit-Learn main repository, Macro-Averaged MAE should be added to **imbalanced-learn** repository instead.  

For **ordinal classification**, we can use multiple metrics, for example: MAE, MSE... As we would use for regression.
But when these classes are imbalanced, one way to deal with imbalance is to use macro-averaged MAE instead, as described on [StackExchange](https://stats.stackexchange.com/questions/338904/measures-of-ordinal-classification-error-for-ordinal-regression) and in the [original paper](https://www.computer.org/csdl/proceedings-article/2009/isda/3872a283/12OmNybfrbj).

The macro-averaged MAE is like the "classic" MAE, except we compute each MAE for each class  and average them, giving equal weights to MAEs. Note that macro-averaged MAE == micro-averaged (or classic) MAE when class are balanced.

To illustrate this, let's consider:
```
y_true_balanced = np.array([1, 1, 1, 2, 2, 2])
y_true_imbalanced = np.array([1, 1, 1, 1, 1, 2])
y_pred = np.array([1, 2, 1, 2, 1, 2])

mean_absolute_error(y_true_balanced, y_pred)
>> 0.33
mean_absolute_error(y_true_imbalanced, y_pred)
>> 0.33
macro_averaged_mean_absolute_error(y_true_balanced, y_pred)
>> 0.33
macro_averaged_mean_absolute_error(y_true_imbalanced, y_pred)
>> 0.2
``` 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
