### PR TITLE
docs: fix simple typo, transfomer -> transformer

### DIFF
--- a/imblearn/pipeline.py
+++ b/imblearn/pipeline.py
@@ -222,7 +222,7 @@ class Pipeline(pipeline.Pipeline):
             finally:
                 cloned_transformer = clone(transformer) if mem else transformer
 
-            # Fit or load from cache the current transfomer
+            # Fit or load from cache the current transformer
             if hasattr(cloned_transformer, "transform") or hasattr(
                 cloned_transformer, "fit_transform"
             ):


### PR DESCRIPTION
There is a small typo in imblearn/pipeline.py.

Should read `transformer` rather than `transfomer`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md