### PR TITLE
FIX make sure that FunctionSampler will bypass validation in fit

### DIFF
--- a/doc/whats_new/v0.7.rst
+++ b/doc/whats_new/v0.7.rst
@@ -54,6 +54,10 @@ Bug fixes
   the targeted class.
   :pr:`769` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- Fix a bug in :class:`imblearn.FunctionSampler` where validation was performed
+  even with `validate=False` when calling `fit`.
+  :pr:`790` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Enhancements
 ............
 

--- a/imblearn/base.py
+++ b/imblearn/base.py
@@ -220,6 +220,38 @@ class FunctionSampler(BaseSampler):
         self.kw_args = kw_args
         self.validate = validate
 
+    def fit(self, X, y):
+        """Check inputs and statistics of the sampler.
+
+        You should use ``fit_resample`` in all cases.
+
+        Parameters
+        ----------
+        X : {array-like, dataframe, sparse matrix} of shape \
+                (n_samples, n_features)
+            Data array.
+
+        y : array-like of shape (n_samples,)
+            Target array.
+
+        Returns
+        -------
+        self : object
+            Return the instance itself.
+        """
+        # we need to overwrite SamplerMixin.fit to bypass the validation
+        if self.validate:
+            check_classification_targets(y)
+            X, y, _ = self._check_X_y(
+                X, y, accept_sparse=self.accept_sparse
+            )
+
+        self.sampling_strategy_ = check_sampling_strategy(
+            self.sampling_strategy, y, self._sampling_type
+        )
+
+        return self
+
     def fit_resample(self, X, y):
         """Resample the dataset.
 

--- a/imblearn/tests/test_base.py
+++ b/imblearn/tests/test_base.py
@@ -108,3 +108,4 @@ def test_function_resampler_fit():
 
     sampler = FunctionSampler(func=func, validate=False)
     sampler.fit(X, y)
+    sampler.fit_resample(X, y)

--- a/imblearn/tests/test_base.py
+++ b/imblearn/tests/test_base.py
@@ -94,3 +94,17 @@ def test_function_sampler_validate():
     y_pred = pipeline.fit(X, y).predict(X)
 
     assert type_of_target(y_pred) == 'continuous'
+
+
+def test_function_resampler_fit():
+    # Check that the validation is bypass when calling `fit`
+    # Non-regression test for:
+    # https://github.com/scikit-learn-contrib/imbalanced-learn/issues/782
+    X = np.array([[1, np.nan], [2, 3], [np.inf, 4]])
+    y = np.array([0, 1, 1])
+
+    def func(X, y):
+        return X[:1], y[:1]
+
+    sampler = FunctionSampler(func=func, validate=False)
+    sampler.fit(X, y)


### PR DESCRIPTION
closes #782 

Make sure that input validations are bypass if `validate=False` even when only `fit` is called.