### PR TITLE
FIX remove smoothed_bootstrap and use only shrinkage param

### DIFF
--- a/doc/over_sampling.rst
+++ b/doc/over_sampling.rst
@@ -80,12 +80,12 @@ It would also work with pandas dataframe::
   >>> df_resampled, y_resampled = ros.fit_resample(df_adult, y_adult)
   >>> df_resampled.head()  # doctest: +SKIP
 
-If repeating samples is an issue, the parameter `smoothed_bootstrap` can be
-turned to `True` to create a smoothed bootstrap. However, the original data
-needs to be numerical. The `shrinkage` parameter controls the dispersion of the
-new generated samples. We show an example illustrate that the new samples are
-not overlapping anymore once using a smoothed bootstrap. This ways of
-generating smoothed bootstrap is also known a Random Over-Sampler Examples
+If repeating samples is an issue, the parameter `shrinkage` allows to create a
+smoothed bootstrap. However, the original data needs to be numerical. The
+`shrinkage` parameter controls the dispersion of the new generated samples. We
+show an example illustrate that the new samples are not overlapping anymore
+once using a smoothed bootstrap. This ways of generating smoothed bootstrap is
+also known a Random Over-Sampler Examples
 (ROSE) :cite:`torelli2014rose`.
 
 .. image:: ./auto_examples/over-sampling/images/sphx_glr_plot_comparison_over_sampling_003.png

--- a/doc/over_sampling.rst
+++ b/doc/over_sampling.rst
@@ -85,7 +85,7 @@ smoothed bootstrap. However, the original data needs to be numerical. The
 `shrinkage` parameter controls the dispersion of the new generated samples. We
 show an example illustrate that the new samples are not overlapping anymore
 once using a smoothed bootstrap. This ways of generating smoothed bootstrap is
-also known a Random Over-Sampler Examples
+also known a Random Over-Sampling Examples
 (ROSE) :cite:`torelli2014rose`.
 
 .. image:: ./auto_examples/over-sampling/images/sphx_glr_plot_comparison_over_sampling_003.png

--- a/doc/whats_new/v0.7.rst
+++ b/doc/whats_new/v0.7.rst
@@ -74,8 +74,8 @@ Enhancements
 
 - Added an option to generate smoothed bootstrap in
   :class:`imblearn.over_sampling.RandomOverSampler`. It is controls by the
-  parameters `smoothed_bootstrap` and `shrinkage`. This method is also known as
-  Random Over-Sampling Examples (ROSE).
+  parameter `shrinkage`. This method is also known as Random Over-Sampling
+  Examples (ROSE).
   :pr:`754` by :user:`Andrea Lorenzon <andrealorenzon>` and
   :user:`Guillaume Lemaitre <glemaitre>`.
 

--- a/examples/over-sampling/plot_comparison_over_sampling.py
+++ b/examples/over-sampling/plot_comparison_over_sampling.py
@@ -144,7 +144,7 @@ fig.tight_layout()
 
 ###############################################################################
 # By default, random over-sampling generates a bootstrap. The parameter
-# `smoothed_bootstrap` allows adding a small perturbation to the generated data
+# `shrinkage` allows adding a small perturbation to the generated data
 # to generate a smoothed bootstrap instead. The plot below shows the difference
 # between the two data generation strategies.
 
@@ -152,7 +152,7 @@ fig, axs = plt.subplots(1, 2, figsize=(15, 7))
 sampler = RandomOverSampler(random_state=0)
 plot_resampling(X, y, sampler, ax=axs[0])
 axs[0].set_title("RandomOverSampler with normal bootstrap")
-sampler = RandomOverSampler(smoothed_bootstrap=True, shrinkage=0.2, random_state=0)
+sampler = RandomOverSampler(shrinkage=0.2, random_state=0)
 plot_resampling(X, y, sampler, ax=axs[1])
 axs[1].set_title("RandomOverSampler with smoothed bootstrap")
 fig.tight_layout()

--- a/examples/over-sampling/plot_shrinkage_effect.py
+++ b/examples/over-sampling/plot_shrinkage_effect.py
@@ -61,9 +61,9 @@ _ = ax.set_ylabel("Feature #2")
 # from the majority class. Indeed, it is due to the fact that these samples
 # of the minority class are repeated during the bootstrap generation.
 #
-# We can set `smoothed_bootstrap=True` to add a small perturbation to the
+# We can set `shrinkage` to a floating value to add a small perturbation to the
 # samples created and therefore create a smoothed bootstrap.
-sampler = RandomOverSampler(smoothed_bootstrap=True, random_state=0)
+sampler = RandomOverSampler(shrinkage=1, random_state=0)
 X_res, y_res = sampler.fit_resample(X, y)
 Counter(y_res)
 
@@ -81,7 +81,7 @@ _ = ax.set_ylabel("Feature #2")
 #
 # The parameter `shrinkage` allows to add more or less perturbation. Let's
 # add more perturbation when generating the smoothed bootstrap.
-sampler = RandomOverSampler(smoothed_bootstrap=True, shrinkage=3, random_state=0)
+sampler = RandomOverSampler(shrinkage=3, random_state=0)
 X_res, y_res = sampler.fit_resample(X, y)
 Counter(y_res)
 
@@ -96,7 +96,7 @@ _ = ax.set_ylabel("Feature #2")
 # %%
 # Increasing the value of `shrinkage` will disperse the new samples. Forcing
 # the shrinkage to 0 will be equivalent to generating a normal bootstrap.
-sampler = RandomOverSampler(smoothed_bootstrap=True, shrinkage=0, random_state=0)
+sampler = RandomOverSampler(shrinkage=0, random_state=0)
 X_res, y_res = sampler.fit_resample(X, y)
 Counter(y_res)
 

--- a/imblearn/over_sampling/_random_over_sampler.py
+++ b/imblearn/over_sampling/_random_over_sampler.py
@@ -37,20 +37,17 @@ class RandomOverSampler(BaseOverSampler):
 
     {random_state}
 
-    smoothed_bootstrap : bool, default=False
-        Whether or not to generate smoothed bootstrap samples. When this option
-        is triggered, be aware that the data to be resampled needs to be
-        numerical data since a Gaussian perturbation will be generated and
-        added to the bootstrap.
+    shrinkage : float or dict, default=None
+        Parameter controlling the shrinkage applied to the covariance matrix
+        when a smoothed bootstrap is generated. The options are:
 
-        .. versionadded:: 0.7
-
-    shrinkage : float or dict, default=1.0
-        Factor to shrink the covariance matrix used to generate the
-        smoothed bootstrap. A factor could be shared by all classes by
-        providing a floating number or different for each class over-sampled
-        by providing a dictionary where the key are the class targeted and the
-        value is the shrinkage factor.
+        - if `None`, a normal bootstrap will be generated without perturbation.
+          It is equivalent to `shrinkage=0` as well;
+        - if a `float` is given, the shrinkage factor will be used for all
+          classes to generate the smoothed bootstrap;
+        - if a `dict` is given, the shrinkage factor will specific for each
+          class. The key correspond to the targeted class and the value is
+          the shrinkage factor.
 
         .. versionadded:: 0.7
 
@@ -63,7 +60,8 @@ class RandomOverSampler(BaseOverSampler):
 
     shrinkage_ : dict or None
         The per-class shrinkage factor used to generate the smoothed bootstrap
-        sample. `None` when `smoothed_bootstrap=False`.
+        sample. `None` when `shrinkage=None` meaning that a normal bootstrap
+        will be generated.
 
         .. versionadded:: 0.7
 
@@ -125,12 +123,10 @@ RandomOverSampler # doctest: +NORMALIZE_WHITESPACE
         *,
         sampling_strategy="auto",
         random_state=None,
-        smoothed_bootstrap=False,
-        shrinkage=1.0,
+        shrinkage=None,
     ):
         super().__init__(sampling_strategy=sampling_strategy)
         self.random_state = random_state
-        self.smoothed_bootstrap = smoothed_bootstrap
         self.shrinkage = shrinkage
 
     def _check_X_y(self, X, y):
@@ -148,34 +144,35 @@ RandomOverSampler # doctest: +NORMALIZE_WHITESPACE
     def _fit_resample(self, X, y):
         random_state = check_random_state(self.random_state)
 
-        if self.smoothed_bootstrap:
-            if isinstance(self.shrinkage, Real):
-                self.shrinkage_ = {
-                    klass: self.shrinkage for klass in self.sampling_strategy_
-                }
-            else:
-                missing_shrinkage_keys = (
-                    self.sampling_strategy_.keys() - self.shrinkage.keys()
+        if self.shrinkage is None:
+            self.shrinkage_ = None
+        elif isinstance(self.shrinkage, Real):
+            self.shrinkage_ = {
+                klass: self.shrinkage for klass in self.sampling_strategy_
+            }
+        else:
+            missing_shrinkage_keys = (
+                self.sampling_strategy_.keys() - self.shrinkage.keys()
+            )
+            if missing_shrinkage_keys:
+                raise ValueError(
+                    f"`shrinkage` should contain a shrinkage factor for "
+                    f"each class that will be resampled. The missing "
+                    f"classes are: {repr(missing_shrinkage_keys)}"
                 )
-                if missing_shrinkage_keys:
-                    raise ValueError(
-                        f"`shrinkage` should contain a shrinkage factor for "
-                        f"each class that will be resampled. The missing "
-                        f"classes are: {repr(missing_shrinkage_keys)}"
-                    )
-                self.shrinkage_ = self.shrinkage
+            self.shrinkage_ = self.shrinkage
+
+        if self.shrinkage_ is not None:
             # smoothed bootstrap imposes to make numerical operation; we need
             # to be sure to have only numerical data in X
             try:
                 X = check_array(X, accept_sparse=["csr", "csc"], dtype="numeric")
             except ValueError as exc:
                 raise ValueError(
-                    "When smoothed_bootstrap=True, X needs to contain only "
+                    "When shrinkage is not None, X needs to contain only "
                     "numerical data to later generate a smoothed bootstrap "
                     "sample."
                 ) from exc
-        else:
-            self.shrinkage_ = None
 
         X_resampled = [X.copy()]
         y_resampled = [y.copy()]
@@ -189,7 +186,7 @@ RandomOverSampler # doctest: +NORMALIZE_WHITESPACE
                 replace=True,
             )
             sample_indices = np.append(sample_indices, bootstrap_indices)
-            if self.smoothed_bootstrap:
+            if self.shrinkage_ is not None:
                 # generate a smoothed bootstrap with a perturbation
                 n_samples, n_features = X.shape
                 smoothing_constant = (4 / ((n_features + 2) * n_samples)) ** (

--- a/imblearn/over_sampling/_random_over_sampler.py
+++ b/imblearn/over_sampling/_random_over_sampler.py
@@ -64,7 +64,7 @@ class RandomOverSampler(BaseOverSampler):
 
     shrinkage_ : dict or None
         The per-class shrinkage factor used to generate the smoothed bootstrap
-        sample. `None` when `shrinkage=None` meaning that a normal bootstrap
+        sample. When `shrinkage=None` a normal bootstrap
         will be generated.
 
         .. versionadded:: 0.7

--- a/imblearn/over_sampling/_random_over_sampler.py
+++ b/imblearn/over_sampling/_random_over_sampler.py
@@ -64,8 +64,7 @@ class RandomOverSampler(BaseOverSampler):
 
     shrinkage_ : dict or None
         The per-class shrinkage factor used to generate the smoothed bootstrap
-        sample. When `shrinkage=None` a normal bootstrap
-        will be generated.
+        sample. When `shrinkage=None` a normal bootstrap will be generated.
 
         .. versionadded:: 0.7
 

--- a/imblearn/over_sampling/_random_over_sampler.py
+++ b/imblearn/over_sampling/_random_over_sampler.py
@@ -4,6 +4,7 @@
 #          Christos Aridas
 # License: MIT
 
+from collections.abc import Mapping
 from numbers import Real
 
 import numpy as np
@@ -151,8 +152,14 @@ RandomOverSampler # doctest: +NORMALIZE_WHITESPACE
             self.shrinkage_ = {
                 klass: self.shrinkage for klass in self.sampling_strategy_
             }
-        else:
+        elif self.shrinkage is None or isinstance(self.shrinkage, Mapping):
             self.shrinkage_ = self.shrinkage
+        else:
+            raise ValueError(
+                f"`shrinkage` should either be a positive floating number or "
+                f"a dictionary mapping a class to a positive floating number. "
+                f"Got {repr(self.shrinkage)} instead."
+            )
 
         if self.shrinkage_ is not None:
             missing_shrinkage_keys = (

--- a/imblearn/over_sampling/tests/test_random_over_sampler.py
+++ b/imblearn/over_sampling/tests/test_random_over_sampler.py
@@ -238,12 +238,17 @@ def test_random_over_sampler_shrinkage_behaviour(data):
     assert disperstion_shrink_1 < disperstion_shrink_5
 
 
-def test_random_over_sampler_shrinkage_error(data):
-    # check that we raise proper error when shrinkage do not contain the
-    # necessary information
+@pytest.mark.parametrize(
+    "shrinkage, err_msg",
+    [
+        ({}, "`shrinkage` should contain a shrinkage factor for each class"),
+        (-1, "The shrinkage factor needs to be >= 0"),
+        ({0: -1}, "The shrinkage factor needs to be >= 0"),
+    ]
+)
+def test_random_over_sampler_shrinkage_error(data, shrinkage, err_msg):
+    # check the validation of the shrinkage parameter
     X, y = data
-    shrinkage = {}
     ros = RandomOverSampler(shrinkage=shrinkage)
-    err_msg = "`shrinkage` should contain a shrinkage factor for each class"
     with pytest.raises(ValueError, match=err_msg):
         ros.fit_resample(X, y)

--- a/imblearn/over_sampling/tests/test_random_over_sampler.py
+++ b/imblearn/over_sampling/tests/test_random_over_sampler.py
@@ -244,6 +244,7 @@ def test_random_over_sampler_shrinkage_behaviour(data):
         ({}, "`shrinkage` should contain a shrinkage factor for each class"),
         (-1, "The shrinkage factor needs to be >= 0"),
         ({0: -1}, "The shrinkage factor needs to be >= 0"),
+        ([1, ], "`shrinkage` should either be a positive floating number or")
     ]
 )
 def test_random_over_sampler_shrinkage_error(data, shrinkage, err_msg):


### PR DESCRIPTION
closes #792

Remove the `smoothed_bootstrap` param and only keep `shrinkage` to control the bootstrapping.