### PR TITLE
FEA implements SMOTEN to handle nominal categorical features

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -168,11 +168,12 @@ Below is a list of the methods currently implemented in this module.
     1. Random minority over-sampling with replacement
     2. SMOTE - Synthetic Minority Over-sampling Technique [8]_
     3. SMOTENC - SMOTE for Nominal Continuous [8]_
-    4. bSMOTE(1 & 2) - Borderline SMOTE of types 1 and 2 [9]_
-    5. SVM SMOTE - Support Vectors SMOTE [10]_
-    6. ADASYN - Adaptive synthetic sampling approach for imbalanced learning [15]_
-    7. KMeans-SMOTE [17]_
-    8. ROSE - Random OverSampling Examples [19]_
+    4. SMOTEN - SMMOTE for Nominal only [8]_
+    5. bSMOTE(1 & 2) - Borderline SMOTE of types 1 and 2 [9]_
+    6. SVM SMOTE - Support Vectors SMOTE [10]_
+    7. ADASYN - Adaptive synthetic sampling approach for imbalanced learning [15]_
+    8. KMeans-SMOTE [17]_
+    9. ROSE - Random OverSampling Examples [19]_
 
 * Over-sampling followed by under-sampling
     1. SMOTE + Tomek links [12]_

--- a/doc/over_sampling.rst
+++ b/doc/over_sampling.rst
@@ -211,6 +211,44 @@ Therefore, it can be seen that the samples generated in the first and last
 columns are belonging to the same categories originally presented without any
 other extra interpolation.
 
+However, :class:`SMOTENC` is working with data composed of categorical data
+only. WHen data are made of only nominal categorical data, one can use the
+:class:`SMOTEN` variant :cite:`chawla2002smote`. The algorithm changes in
+two ways:
+
+* the nearest neighbors search does not rely on the Euclidean distance. Indeed,
+  the value difference metric (VDM) also implemented in the class
+  :class:`~imblearn.metrics.ValueDifferenceMetric` is used.
+* the new sample generation is based on majority vote per feature to generate
+  the most common category seen in the neighbors samples.
+
+Let's take the following example::
+
+   >>> import numpy as np
+   >>> X = np.array(["green"] * 5 + ["red"] * 10 + ["blue"] * 7,
+   ...              dtype=object).reshape(-1, 1)
+   >>> y = np.array(["apple"] * 5 + ["not apple"] * 3 + ["apple"] * 7 +
+   ...              ["not apple"] * 5 + ["apple"] * 2, dtype=object)
+
+We generate a dataset associating a color to being an apple or not an apple.
+We strongly associated "green" and "red" to being an apple. The minority class
+being "not apple", we expect new data generated belonging to the category
+"blue"::
+
+   >>> from imblearn.over_sampling import SMOTEN
+   >>> sampler = SMOTEN(random_state=0)
+   >>> X_res, y_res = sampler.fit_resample(X, y)
+   >>> X_res[y.size:]
+   array([['blue'],
+           ['blue'],
+           ['blue'],
+           ['blue'],
+           ['blue'],
+           ['blue']], dtype=object)
+   >>> y_res[y.size:]
+   array(['not apple', 'not apple', 'not apple', 'not apple', 'not apple',
+          'not apple'], dtype=object)
+
 Mathematical formulation
 ========================
 

--- a/doc/references/over_sampling.rst
+++ b/doc/references/over_sampling.rst
@@ -27,6 +27,7 @@ SMOTE algorithms
 
    SMOTE
    SMOTENC
+   SMOTEN
    ADASYN
    BorderlineSMOTE
    KMeansSMOTE

--- a/doc/whats_new/v0.8.rst
+++ b/doc/whats_new/v0.8.rst
@@ -19,6 +19,10 @@ New features
   compute pairwise distances between samples containing only nominal values.
   :pr:`796` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- Add the class :class:`imblearn.over_sampling.SMOTEN` to over-sample data
+  only containing nominal categorical features.
+  :pr:`802` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Enhancements
 ............
 

--- a/imblearn/over_sampling/__init__.py
+++ b/imblearn/over_sampling/__init__.py
@@ -10,6 +10,7 @@ from ._smote import BorderlineSMOTE
 from ._smote import KMeansSMOTE
 from ._smote import SVMSMOTE
 from ._smote import SMOTENC
+from ._smote import SMOTEN
 
 __all__ = [
     "ADASYN",
@@ -19,4 +20,5 @@ __all__ = [
     "BorderlineSMOTE",
     "SVMSMOTE",
     "SMOTENC",
+    "SMOTEN",
 ]

--- a/imblearn/over_sampling/_adasyn.py
+++ b/imblearn/over_sampling/_adasyn.py
@@ -178,3 +178,8 @@ ADASYN # doctest: +NORMALIZE_WHITESPACE
         y_resampled = np.hstack(y_resampled)
 
         return X_resampled, y_resampled
+
+    def _more_tags(self):
+        return {
+            "X_types": ["2darray", "string"],
+        }

--- a/imblearn/over_sampling/_adasyn.py
+++ b/imblearn/over_sampling/_adasyn.py
@@ -50,6 +50,15 @@ class ADASYN(BaseOverSampler):
     --------
     SMOTE : Over-sample using SMOTE.
 
+    SMOTENC : Over-sample using SMOTE for continuous and categorical features.
+
+    SMOTEN : Over-sample using the SMOTE variable specifically for categorical
+        features only.
+
+    SVMSMOTE : Over-sample using SVM-SMOTE variant.
+
+    BorderlineSMOTE : Over-sample using Borderline-SMOTE variant.
+
     Notes
     -----
     The implementation is based on [1]_.

--- a/imblearn/over_sampling/_adasyn.py
+++ b/imblearn/over_sampling/_adasyn.py
@@ -181,5 +181,5 @@ ADASYN # doctest: +NORMALIZE_WHITESPACE
 
     def _more_tags(self):
         return {
-            "X_types": ["2darray", "string"],
+            "X_types": ["2darray"],
         }

--- a/imblearn/over_sampling/_random_over_sampler.py
+++ b/imblearn/over_sampling/_random_over_sampler.py
@@ -76,6 +76,9 @@ class RandomOverSampler(BaseOverSampler):
 
     SMOTENC : Over-sample using SMOTE for continuous and categorical features.
 
+    SMOTEN : Over-sample using the SMOTE variable specifically for categorical
+        features only.
+
     SVMSMOTE : Over-sample using SVM-SMOTE variant.
 
     ADASYN : Over-sample using ADASYN.

--- a/imblearn/over_sampling/_smote.py
+++ b/imblearn/over_sampling/_smote.py
@@ -1444,3 +1444,6 @@ class SMOTEN(SMOTE):
         y_resampled = np.hstack(y_resampled)
 
         return X_resampled, y_resampled
+
+    def _more_tags(self):
+        return {"X_types": ["2darray", "dataframe", "string"]}

--- a/imblearn/over_sampling/_smote.py
+++ b/imblearn/over_sampling/_smote.py
@@ -450,6 +450,9 @@ class SVMSMOTE(BaseSMOTE):
 
     SMOTENC : Over-sample using SMOTE for continuous and categorical features.
 
+    SMOTEN : Over-sample using the SMOTE variable specifically for categorical
+        features only.
+
     BorderlineSMOTE : Over-sample using Borderline-SMOTE.
 
     ADASYN : Over-sample using ADASYN.
@@ -645,6 +648,9 @@ class SMOTE(BaseSMOTE):
     --------
     SMOTENC : Over-sample using SMOTE for continuous and categorical features.
 
+    SMOTEN : Over-sample using the SMOTE variable specifically for categorical
+        features only.
+
     BorderlineSMOTE : Over-sample using the borderline-SMOTE variant.
 
     SVMSMOTE : Over-sample using the SVM-SMOTE variant.
@@ -812,6 +818,9 @@ class SMOTENC(SMOTE):
     See Also
     --------
     SMOTE : Over-sample using SMOTE.
+
+    SMOTEN : Over-sample using the SMOTE variable specifically for categorical
+        features only.
 
     SVMSMOTE : Over-sample using SVM-SMOTE variant.
 
@@ -1101,6 +1110,11 @@ class KMeansSMOTE(BaseSMOTE):
     See Also
     --------
     SMOTE : Over-sample using SMOTE.
+
+    SMOTENC : Over-sample using SMOTE for continuous and categorical features.
+
+    SMOTEN : Over-sample using the SMOTE variable specifically for categorical
+        features only.
 
     SVMSMOTE : Over-sample using SVM-SMOTE variant.
 

--- a/imblearn/over_sampling/tests/test_smoten.py
+++ b/imblearn/over_sampling/tests/test_smoten.py
@@ -1,0 +1,30 @@
+from collections import Counter
+
+import numpy as np
+import pytest
+
+from imblearn.over_sampling import SMOTEN
+
+
+@pytest.fixture
+def data():
+    rng = np.random.RandomState(0)
+
+    feature_1 = ["A"] * 10 + ["B"] * 20 + ["C"] * 30
+    feature_2 = ["A"] * 40 + ["B"] * 20
+    feature_3 = ["A"] * 20 + ["B"] * 20 + ["C"] * 10 + ["D"] * 10
+    X = np.array([feature_1, feature_2, feature_3], dtype=object).T
+    rng.shuffle(X)
+    y = np.array([0] * 20 + [1] * 40, dtype=np.int32)
+    y_labels = np.array(["not apple", "apple"], dtype=object)
+    y = y_labels[y]
+    return X, y
+
+
+def test_smoten(data):
+    X, y = data
+    print(X, y)
+    sampler = SMOTEN(random_state=0)
+    X_res, y_res = sampler.fit_resample(X, y)
+    print(X_res, y_res)
+    print(Counter(y_res))

--- a/imblearn/over_sampling/tests/test_smoten.py
+++ b/imblearn/over_sampling/tests/test_smoten.py
@@ -1,5 +1,3 @@
-from collections import Counter
-
 import numpy as np
 import pytest
 
@@ -22,9 +20,35 @@ def data():
 
 
 def test_smoten(data):
+    # overall check for SMOTEN
     X, y = data
-    print(X, y)
     sampler = SMOTEN(random_state=0)
     X_res, y_res = sampler.fit_resample(X, y)
-    print(X_res, y_res)
-    print(Counter(y_res))
+
+    assert X_res.shape == (80, 3)
+    assert y_res.shape == (80,)
+
+
+def test_smoten_resampling():
+    # check if the SMOTEN resample data as expected
+    # we generate data such that "not apple" will be the minority class and
+    # samples from this class will be generated. We will force the "blue"
+    # category to be associated with this class. Therefore, the new generated
+    # samples should as well be from the "blue" category.
+    X = np.array(["green"] * 5 + ["red"] * 10 + ["blue"] * 7, dtype=object).reshape(
+        -1, 1
+    )
+    y = np.array(
+        ["apple"] * 5
+        + ["not apple"] * 3
+        + ["apple"] * 7
+        + ["not apple"] * 5
+        + ["apple"] * 2,
+        dtype=object,
+    )
+    sampler = SMOTEN(random_state=0)
+    X_res, y_res = sampler.fit_resample(X, y)
+
+    X_generated, y_generated = X_res[X.shape[0] :], y_res[X.shape[0] :]
+    np.testing.assert_array_equal(X_generated, "blue")
+    np.testing.assert_array_equal(y_generated, "not apple")


### PR DESCRIPTION
closes #565 

Implements SMOTE for nominal categorical features only. It uses the VDM distance and a majority vote regarding the per feature to create new categories from the k-NN.