### PR TITLE
TST create sparse and dataframe tags for X_types

### DIFF
--- a/imblearn/base.py
+++ b/imblearn/base.py
@@ -130,6 +130,9 @@ class BaseSampler(SamplerMixin):
         X, y = self._validate_data(X, y, reset=True, accept_sparse=accept_sparse)
         return X, y, binarize_y
 
+    def _more_tags(self):
+        return {"X_types": ["2darray", "sparse", "dataframe"]}
+
 
 def _identity(X, y):
     return X, y

--- a/imblearn/over_sampling/_random_over_sampler.py
+++ b/imblearn/over_sampling/_random_over_sampler.py
@@ -241,7 +241,7 @@ RandomOverSampler # doctest: +NORMALIZE_WHITESPACE
 
     def _more_tags(self):
         return {
-            "X_types": ["2darray", "string"],
+            "X_types": ["2darray", "string", "sparse", "dataframe"],
             "sample_indices": True,
             "allow_nan": True,
         }

--- a/imblearn/under_sampling/_prototype_selection/_random_under_sampler.py
+++ b/imblearn/under_sampling/_prototype_selection/_random_under_sampler.py
@@ -108,7 +108,10 @@ RandomUnderSampler # doctest: +NORMALIZE_WHITESPACE
                 index_target_class = slice(None)
 
             idx_under = np.concatenate(
-                (idx_under, np.flatnonzero(y == target_class)[index_target_class],),
+                (
+                    idx_under,
+                    np.flatnonzero(y == target_class)[index_target_class],
+                ),
                 axis=0,
             )
 
@@ -118,7 +121,7 @@ RandomUnderSampler # doctest: +NORMALIZE_WHITESPACE
 
     def _more_tags(self):
         return {
-            "X_types": ["2darray", "string"],
+            "X_types": ["2darray", "string", "sparse", "dataframe"],
             "sample_indices": True,
             "allow_nan": True,
         }


### PR DESCRIPTION
closes #650 

Add tags "sparse" and "dataframe" as two tags that could be added to `X_types`.
