### PR TITLE
DEP deprecate warns context manager

### DIFF
--- a/doc/whats_new/v0.8.rst
+++ b/doc/whats_new/v0.8.rst
@@ -50,3 +50,10 @@ Bug fixes
 - Fix a bug in :class:`imblearn.FunctionSampler` where validation was performed
   even with `validate=False` when calling `fit`.
   :pr:`790` by :user:`Guillaume Lemaitre <glemaitre>`.
+
+Deprecation
+...........
+
+- The context manager :func:`imblearn.utils.testing.warns` is deprecated in 0.8
+  and will be removed 1.0.
+  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.

--- a/doc/whats_new/v0.8.rst
+++ b/doc/whats_new/v0.8.rst
@@ -56,4 +56,4 @@ Deprecation
 
 - The context manager :func:`imblearn.utils.testing.warns` is deprecated in 0.8
   and will be removed 1.0.
-  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`815` by :user:`Guillaume Lemaitre <glemaitre>`.

--- a/imblearn/utils/testing.py
+++ b/imblearn/utils/testing.py
@@ -6,6 +6,7 @@
 
 import inspect
 import pkgutil
+import warnings
 from contextlib import contextmanager
 from importlib import import_module
 from re import compile
@@ -18,7 +19,9 @@ from sklearn.base import BaseEstimator
 from sklearn.utils._testing import ignore_warnings
 
 
-def all_estimators(type_filter=None,):
+def all_estimators(
+    type_filter=None,
+):
     """Get a list of all estimators from imblearn.
 
     This function crawls the module and gets all classes that inherit
@@ -120,6 +123,10 @@ def warns(expected_warning, match=None):
     and raise a failure exception otherwise. It can be used within a context
     manager ``with``.
 
+    .. deprecated:: 0.8
+       This function is deprecated in 0.8 and will be removed in 0.10.
+       Use `pytest.warns()` instead.
+
     Parameters
     ----------
     expected_warning : Warning
@@ -134,13 +141,16 @@ def warns(expected_warning, match=None):
 
     Examples
     --------
-
     >>> import warnings
     >>> from imblearn.utils.testing import warns
     >>> with warns(UserWarning, match=r'must be \d+$'):
     ...     warnings.warn("value must be 42", UserWarning)
-
     """
+    warnings.warn(
+        "The warns function is deprecated in 0.8 and will be removed in 0.10. "
+        "Use pytest.warns() instead."
+    )
+
     with _warns(expected_warning) as record:
         yield
 

--- a/imblearn/utils/tests/test_testing.py
+++ b/imblearn/utils/tests/test_testing.py
@@ -3,7 +3,7 @@
 #          Christos Aridas
 # License: MIT
 
-from pytest import raises
+import pytest
 
 from imblearn.base import SamplerMixin
 from imblearn.utils.testing import all_estimators
@@ -23,17 +23,18 @@ def test_all_estimators():
 
     # check that an error is raised when the type is unknown
     type_filter = "rnd"
-    with raises(ValueError, match="Parameter type_filter must be 'sampler'"):
+    with pytest.raises(ValueError, match="Parameter type_filter must be 'sampler'"):
         all_estimators(type_filter=type_filter)
 
 
+@pytest.mark.filterwarnings("ignore:The warns function is deprecated in 0.8")
 def test_warns():
     import warnings
 
     with warns(UserWarning, match=r"must be \d+$"):
         warnings.warn("value must be 42", UserWarning)
 
-    with raises(AssertionError, match="pattern not found"):
+    with pytest.raises(AssertionError, match="pattern not found"):
         with warns(UserWarning, match=r"must be \d+$"):
             warnings.warn("this is not here", UserWarning)
 
@@ -44,7 +45,17 @@ def test_warns():
 
     a, b, c = ("aaa", "bbbbbbbbbb", "cccccccccc")
     expected_msg = r"'{}' pattern not found in \['{}', '{}'\]".format(a, b, c)
-    with raises(AssertionError, match=expected_msg):
+    with pytest.raises(AssertionError, match=expected_msg):
         with warns(UserWarning, match=r"aaa"):
             warnings.warn("bbbbbbbbbb", UserWarning)
             warnings.warn("cccccccccc", UserWarning)
+
+
+# TODO: remove in 0.9
+def test_warns_deprecation():
+    import warnings
+
+    with pytest.warns(None) as record:
+        with warns(UserWarning):
+            warnings.warn("value must be 42")
+    assert "The warns function is deprecated" in str(record[0].message)


### PR DESCRIPTION
closes #807

Deprecate `imblearn.utils.testing.warns` context manager.