### PR TITLE
[ENH] Pass n_jobs parameter through SMOTE to NearestNeighbors

### DIFF
--- a/imblearn/over_sampling/_smote/base.py
+++ b/imblearn/over_sampling/_smote/base.py
@@ -52,6 +52,7 @@ class BaseSMOTE(BaseOverSampler):
         self.nn_k_ = check_neighbors_object(
             "k_neighbors", self.k_neighbors, additional_neighbor=1
         )
+        self.nn_k_.set_params(**{"n_jobs": self.n_jobs})
 
     def _make_samples(
         self, X, y_dtype, y_type, nn_data, nn_num, n_samples, step_size=1.0


### PR DESCRIPTION
#### Reference Issue
This closes #820 

#### What does this implement/fix? Explain your changes.
This PR adds support for using the `n_jobs` parameter of `sklearn.neighbors.NearestNeighbors` in the SMOTE based algorithms. Currently, this parameter is not passed down to the `NearestNeighbors` object. The potential time savings can be quite significant on imbalanced medium sized or large datasets, based on the loose benchmark in #820 .

#### Any other comments?
- [x] Changes pass PEP8 (no issues on the changed line)
- [x] Changes pass pyflakes
- [x] Passes existing pytests

If this needs new pytests, I would be happy to include some in this PR.

<details>
<summary> Pytest results </summary>

```
pytest --cov=imblearn imblearn
========================================================= test session starts =========================================================
platform linux -- Python 3.7.10, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /home/nicholasb/NVIDIA/imbalanced-learn, configfile: setup.cfg
plugins: cov-2.11.1, anyio-2.2.0
collected 1995 items / 4 skipped / 1991 selected                                                                                      

imblearn/base.py .                                                                                                              [  0%]
imblearn/pipeline.py ..                                                                                                         [  0%]
imblearn/combine/_smote_enn.py .                                                                                                [  0%]
imblearn/combine/_smote_tomek.py .                                                                                              [  0%]
imblearn/combine/tests/test_smote_enn.py ........                                                                               [  0%]
imblearn/combine/tests/test_smote_tomek.py .......                                                                              [  1%]
imblearn/datasets/_imbalance.py .                                                                                               [  1%]
imblearn/datasets/tests/test_imbalance.py ..........                                                                            [  1%]
imblearn/datasets/tests/test_zenodo.py X.....                                                                                   [  1%]
imblearn/ensemble/_bagging.py .                                                                                                 [  1%]
imblearn/ensemble/_easy_ensemble.py .                                                                                           [  1%]
imblearn/ensemble/_forest.py .                                                                                                  [  2%]
imblearn/ensemble/_weight_boosting.py .                                                                                         [  2%]
imblearn/ensemble/tests/test_bagging.py ....................................................................................... [  6%]
.............................................................................................                                   [ 11%]
imblearn/ensemble/tests/test_easy_ensemble.py ..............                                                                    [ 11%]
imblearn/ensemble/tests/test_forest.py .............                                                                            [ 12%]
imblearn/ensemble/tests/test_weight_boosting.py ......                                                                          [ 12%]
imblearn/keras/_generator.py ss                                                                                                 [ 12%]
imblearn/metrics/_classification.py .......                                                                                     [ 13%]
imblearn/metrics/pairwise.py .                                                                                                  [ 13%]
imblearn/metrics/tests/test_classification.py ..................................................                                [ 15%]
imblearn/metrics/tests/test_pairwise.py ....................................................................................... [ 20%]
.............................................                                                                                   [ 22%]
imblearn/metrics/tests/test_score_objects.py ................                                                                   [ 23%]
imblearn/over_sampling/_adasyn.py .                                                                                             [ 23%]
imblearn/over_sampling/_random_over_sampler.py .                                                                                [ 23%]
imblearn/over_sampling/_smote/base.py ...                                                                                       [ 23%]
imblearn/over_sampling/_smote/cluster.py .                                                                                      [ 23%]
imblearn/over_sampling/_smote/filter.py ..                                                                                      [ 23%]
imblearn/over_sampling/_smote/tests/test_borderline_smote.py ...                                                                [ 23%]
imblearn/over_sampling/_smote/tests/test_kmeans_smote.py ..............                                                         [ 24%]
imblearn/over_sampling/_smote/tests/test_smote.py .....                                                                         [ 24%]
imblearn/over_sampling/_smote/tests/test_smote_nc.py ................                                                           [ 25%]
imblearn/over_sampling/_smote/tests/test_smoten.py ..                                                                           [ 25%]
imblearn/over_sampling/_smote/tests/test_svm_smote.py .                                                                         [ 25%]
imblearn/over_sampling/tests/test_adasyn.py .....                                                                               [ 25%]
imblearn/over_sampling/tests/test_random_over_sampler.py ......................                                                 [ 26%]
imblearn/tests/test_base.py ............                                                                                        [ 27%]
imblearn/tests/test_common.py ................................................................................................. [ 32%]
......x........................................................................................................................ [ 38%]
............................................................................................................................... [ 45%]
............................................................................................................................... [ 51%]
............................................................................................................................... [ 57%]
............................................................................................................................... [ 64%]
............................................................................................................................... [ 70%]
............................................................................................................................... [ 76%]
....................................................................................X...........X...........x.................. [ 83%]
............................................................................................................................... [ 89%]
.                                                                                                                               [ 89%]
imblearn/tests/test_exceptions.py .                                                                                             [ 89%]
imblearn/tests/test_pipeline.py ..............................................................                                  [ 92%]
imblearn/under_sampling/_prototype_generation/_cluster_centroids.py .                                                           [ 92%]
imblearn/under_sampling/_prototype_generation/tests/test_cluster_centroids.py ...........                                       [ 93%]
imblearn/under_sampling/_prototype_selection/_condensed_nearest_neighbour.py s                                                  [ 93%]
imblearn/under_sampling/_prototype_selection/_edited_nearest_neighbours.py ...                                                  [ 93%]
imblearn/under_sampling/_prototype_selection/_instance_hardness_threshold.py .                                                  [ 93%]
imblearn/under_sampling/_prototype_selection/_nearmiss.py .                                                                     [ 93%]
imblearn/under_sampling/_prototype_selection/_neighbourhood_cleaning_rule.py .                                                  [ 93%]
imblearn/under_sampling/_prototype_selection/_one_sided_selection.py .                                                          [ 93%]
imblearn/under_sampling/_prototype_selection/_random_under_sampler.py .                                                         [ 93%]
imblearn/under_sampling/_prototype_selection/_tomek_links.py .                                                                  [ 94%]
imblearn/under_sampling/_prototype_selection/tests/test_allknn.py .....                                                         [ 94%]
imblearn/under_sampling/_prototype_selection/tests/test_condensed_nearest_neighbour.py ....                                     [ 94%]
imblearn/under_sampling/_prototype_selection/tests/test_edited_nearest_neighbours.py ......                                     [ 94%]
imblearn/under_sampling/_prototype_selection/tests/test_instance_hardness_threshold.py ......                                   [ 95%]
imblearn/under_sampling/_prototype_selection/tests/test_nearmiss.py ......                                                      [ 95%]
imblearn/under_sampling/_prototype_selection/tests/test_neighbourhood_cleaning_rule.py .....                                    [ 95%]
imblearn/under_sampling/_prototype_selection/tests/test_one_sided_selection.py ....                                             [ 95%]
imblearn/under_sampling/_prototype_selection/tests/test_random_under_sampler.py ......                                          [ 96%]
imblearn/under_sampling/_prototype_selection/tests/test_repeated_edited_nearest_neighbours.py ........                          [ 96%]
imblearn/under_sampling/_prototype_selection/tests/test_tomek_links.py ..                                                       [ 96%]
imblearn/utils/estimator_checks.py .                                                                                            [ 96%]
imblearn/utils/testing.py .                                                                                                     [ 96%]
imblearn/utils/tests/test_deprecation.py .                                                                                      [ 96%]
imblearn/utils/tests/test_docstring.py ...                                                                                      [ 96%]
imblearn/utils/tests/test_estimator_checks.py ...                                                                               [ 97%]
imblearn/utils/tests/test_show_versions.py ...                                                                                  [ 97%]
imblearn/utils/tests/test_testing.py ...                                                                                        [ 97%]
imblearn/utils/tests/test_validation.py ....................................................                                    [100%]

========================================================== warnings summary ===========================================================
../../miniconda3/envs/imblearn-dev/lib/python3.7/site-packages/sklearn/utils/estimator_checks.py:370
../../miniconda3/envs/imblearn-dev/lib/python3.7/site-packages/sklearn/utils/estimator_checks.py:370
  /home/nicholasb/miniconda3/envs/imblearn-dev/lib/python3.7/site-packages/sklearn/utils/estimator_checks.py:370: SkipTestWarning: Can't instantiate estimator Pipeline parameters ['steps']
    warnings.warn(msg, SkipTestWarning)

../../miniconda3/envs/imblearn-dev/lib/python3.7/site-packages/sklearn/utils/estimator_checks.py:370
../../miniconda3/envs/imblearn-dev/lib/python3.7/site-packages/sklearn/utils/estimator_checks.py:370
  /home/nicholasb/miniconda3/envs/imblearn-dev/lib/python3.7/site-packages/sklearn/utils/estimator_checks.py:370: SkipTestWarning: Can't instantiate estimator SMOTENC parameters ['categorical_features']
    warnings.warn(msg, SkipTestWarning)

imblearn/ensemble/tests/test_bagging.py::test_balanced_bagging_classifier_samplers[sampler2-15]
  /home/nicholasb/NVIDIA/imbalanced-learn/imblearn/under_sampling/_prototype_generation/_cluster_centroids.py:172: ConvergenceWarning: Number of distinct clusters (9) found smaller than n_clusters (15). Possibly due to duplicate points in X.
    self.estimator_.fit(_safe_indexing(X, target_class_indices))

imblearn/metrics/tests/test_classification.py::test_sensitivity_specificity_unused_pos_label
imblearn/utils/testing.py::imblearn.utils.testing.warns
imblearn/utils/tests/test_deprecation.py::test_deprecate_parameter
imblearn/utils/tests/test_deprecation.py::test_deprecate_parameter
imblearn/utils/tests/test_validation.py::test_sampling_strategy_dict_over_sampling
  /home/nicholasb/NVIDIA/imbalanced-learn/imblearn/utils/testing.py:150: UserWarning: The warns function is deprecated in 0.8 and will be removed in 0.10. Use pytest.warns() instead.
    "The warns function is deprecated in 0.8 and will be removed in 0.10. "

imblearn/tests/test_common.py::test_estimators_compatibility_sklearn[FunctionSampler()-check_estimator_sparse_data]
  /home/nicholasb/miniconda3/envs/imblearn-dev/lib/python3.7/site-packages/sklearn/utils/validation.py:596: UserWarning: Can't check dok sparse matrix for nan or inf.
    accept_large_sparse=accept_large_sparse)

-- Docs: https://docs.pytest.org/en/stable/warnings.html

---------- coverage: platform linux, python 3.7.10-final-0 -----------
Name                                                                                            Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------------------------------------------------------------------------------------------
imblearn/__init__.py                                                                               33      2      0      0    94%   88-89
imblearn/_version.py                                                                                1      0      0      0   100%
imblearn/base.py                                                                                   69      1      8      0    99%   113
imblearn/combine/__init__.py                                                                        3      0      0      0   100%
imblearn/combine/_smote_enn.py                                                                     40      0     10      0   100%
imblearn/combine/_smote_tomek.py                                                                   40      0     10      0   100%
imblearn/combine/tests/__init__.py                                                                  0      0      0      0   100%
imblearn/combine/tests/test_smote_enn.py                                                           64      0      0      0   100%
imblearn/combine/tests/test_smote_tomek.py                                                         57      0      0      0   100%
imblearn/datasets/__init__.py                                                                       3      0      0      0   100%
imblearn/datasets/_imbalance.py                                                                    17      2      6      2    83%   104, 112
imblearn/datasets/_zenodo.py                                                                       62      7     24      3    86%   270-275, 277, 282->289
imblearn/datasets/tests/__init__.py                                                                 0      0      0      0   100%
imblearn/datasets/tests/test_imbalance.py                                                          29      0      2      0   100%
imblearn/datasets/tests/test_zenodo.py                                                             35      4      2      0    89%   53-54, 72-73
imblearn/ensemble/__init__.py                                                                       5      0      0      0   100%
imblearn/ensemble/_bagging.py                                                                      52      1     18      1    97%   329
imblearn/ensemble/_easy_ensemble.py                                                                38      0     12      0   100%
imblearn/ensemble/_forest.py                                                                      152      4     70      8    95%   59->61, 368, 384->388, 419, 470, 562->566, 597->600, 626
imblearn/ensemble/_weight_boosting.py                                                              89      2     24      5    94%   194->198, 198->205, 290, 300, 313->317
imblearn/ensemble/tests/__init__.py                                                                 0      0      0      0   100%
imblearn/ensemble/tests/test_bagging.py                                                           207      0     14      0   100%
imblearn/ensemble/tests/test_easy_ensemble.py                                                      99      0      8      0   100%
imblearn/ensemble/tests/test_forest.py                                                             97      0      2      0   100%
imblearn/ensemble/tests/test_weight_boosting.py                                                    45      0      4      0   100%
imblearn/exceptions.py                                                                              2      0      0      0   100%
imblearn/keras/__init__.py                                                                          3      0      0      0   100%
imblearn/keras/_generator.py                                                                       70     33     14      1    45%   20, 28, 36, 149-158, 161-171, 174, 177-196, 282
imblearn/keras/tests/__init__.py                                                                    0      0      0      0   100%
imblearn/keras/tests/test_generator.py                                                             58     53      8      0     8%   9-134
imblearn/metrics/__init__.py                                                                        8      0      0      0   100%
imblearn/metrics/_classification.py                                                               218      8     84     11    94%   36-37, 201, 203, 229, 230->232, 232->236, 275, 277, 656->660, 672, 747->750, 759->770
imblearn/metrics/pairwise.py                                                                       45      0     18      0   100%
imblearn/metrics/tests/__init__.py                                                                  0      0      0      0   100%
imblearn/metrics/tests/test_classification.py                                                     194      0     10      0   100%
imblearn/metrics/tests/test_pairwise.py                                                            97      0     12      0   100%
imblearn/metrics/tests/test_score_objects.py                                                       29      0      0      0   100%
imblearn/over_sampling/__init__.py                                                                  9      0      0      0   100%
imblearn/over_sampling/_adasyn.py                                                                  65      5     14      3    90%   135, 163-165, 175
imblearn/over_sampling/_random_over_sampler.py                                                     71      0     26      0   100%
imblearn/over_sampling/_smote/__init__.py                                                           7      0      0      0   100%
imblearn/over_sampling/_smote/base.py                                                             197      1     49      1    99%   495
imblearn/over_sampling/_smote/cluster.py                                                           84      0     28      0   100%
imblearn/over_sampling/_smote/filter.py                                                           118      8     44      8    89%   165, 189->154, 218, 351, 386->402, 425-429, 430->359, 432
imblearn/over_sampling/_smote/tests/__init__.py                                                     0      0      0      0   100%
imblearn/over_sampling/_smote/tests/test_borderline_smote.py                                       21      0      0      0   100%
imblearn/over_sampling/_smote/tests/test_kmeans_smote.py                                           50      0      0      0   100%
imblearn/over_sampling/_smote/tests/test_smote.py                                                  39      0      0      0   100%
imblearn/over_sampling/_smote/tests/test_smote_nc.py                                              136      0      8      0   100%
imblearn/over_sampling/_smote/tests/test_smoten.py                                                 28      0      0      0   100%
imblearn/over_sampling/_smote/tests/test_svm_smote.py                                              18      0      0      0   100%
imblearn/over_sampling/base.py                                                                      4      0      0      0   100%
imblearn/over_sampling/tests/__init__.py                                                            0      0      0      0   100%
imblearn/over_sampling/tests/test_adasyn.py                                                        33      0      0      0   100%
imblearn/over_sampling/tests/test_random_over_sampler.py                                          123      0     10      0   100%
imblearn/pipeline.py                                                                               92      1     34      3    97%   151, 219->231, 346->exit
imblearn/tensorflow/__init__.py                                                                     2      0      0      0   100%
imblearn/tensorflow/_generator.py                                                                  32     21      8      0    28%   71-98
imblearn/tensorflow/tests/__init__.py                                                               0      0      0      0   100%
imblearn/tensorflow/tests/test_generator.py                                                        90     80     14      0    10%   18-174
imblearn/tests/__init__.py                                                                          0      0      0      0   100%
imblearn/tests/test_base.py                                                                        59      0      0      0   100%
imblearn/tests/test_common.py                                                                      34      0      6      0   100%
imblearn/tests/test_exceptions.py                                                                   6      0      0      0   100%
imblearn/tests/test_pipeline.py                                                                   688     16     16      0    98%   77, 85, 177, 180, 183, 186, 1191-1216
imblearn/under_sampling/__init__.py                                                                12      0      0      0   100%
imblearn/under_sampling/_prototype_generation/__init__.py                                           2      0      0      0   100%
imblearn/under_sampling/_prototype_generation/_cluster_centroids.py                                69      0     24      0   100%
imblearn/under_sampling/_prototype_generation/tests/__init__.py                                     0      0      0      0   100%
imblearn/under_sampling/_prototype_generation/tests/test_cluster_centroids.py                      74      0      4      0   100%
imblearn/under_sampling/_prototype_selection/__init__.py                                           11      0      0      0   100%
imblearn/under_sampling/_prototype_selection/_condensed_nearest_neighbour.py                       66      0     20      0   100%
imblearn/under_sampling/_prototype_selection/_edited_nearest_neighbours.py                        122      0     32      1    99%   147->150
imblearn/under_sampling/_prototype_selection/_instance_hardness_threshold.py                       49      0     10      0   100%
imblearn/under_sampling/_prototype_selection/_nearmiss.py                                          73      1     22      2    97%   151, 244->270
imblearn/under_sampling/_prototype_selection/_neighbourhood_cleaning_rule.py                       58      0     10      0   100%
imblearn/under_sampling/_prototype_selection/_one_sided_selection.py                               60      0     12      0   100%
imblearn/under_sampling/_prototype_selection/_random_under_sampler.py                              32      0      6      0   100%
imblearn/under_sampling/_prototype_selection/_tomek_links.py                                       32      0     12      0   100%
imblearn/under_sampling/_prototype_selection/tests/__init__.py                                      0      0      0      0   100%
imblearn/under_sampling/_prototype_selection/tests/test_allknn.py                                  43      0      0      0   100%
imblearn/under_sampling/_prototype_selection/tests/test_condensed_nearest_neighbour.py             36      0      0      0   100%
imblearn/under_sampling/_prototype_selection/tests/test_edited_nearest_neighbours.py               47      0      0      0   100%
imblearn/under_sampling/_prototype_selection/tests/test_instance_hardness_threshold.py             50      0      4      0   100%
imblearn/under_sampling/_prototype_selection/tests/test_nearmiss.py                                40      0      6      0   100%
imblearn/under_sampling/_prototype_selection/tests/test_neighbourhood_cleaning_rule.py             24      0      0      0   100%
imblearn/under_sampling/_prototype_selection/tests/test_one_sided_selection.py                     38      0      0      0   100%
imblearn/under_sampling/_prototype_selection/tests/test_random_under_sampler.py                    61      0      4      0   100%
imblearn/under_sampling/_prototype_selection/tests/test_repeated_edited_nearest_neighbours.py      51      0      0      0   100%
imblearn/under_sampling/_prototype_selection/tests/test_tomek_links.py                             15      0      0      0   100%
imblearn/under_sampling/base.py                                                                     7      0      0      0   100%
imblearn/utils/__init__.py                                                                          5      0      0      0   100%
imblearn/utils/_docstring.py                                                                        9      0      0      0   100%
imblearn/utils/_show_versions.py                                                                   36      0     14      0   100%
imblearn/utils/_validation.py                                                                     205      0    117      2    99%   262->exit, 538->exit
imblearn/utils/deprecation.py                                                                      10      0      6      2    88%   36->exit, 44->exit
imblearn/utils/estimator_checks.py                                                                255      9     58      3    96%   88-92, 179-181, 184-187
imblearn/utils/testing.py                                                                          61      0     37      0   100%
imblearn/utils/tests/__init__.py                                                                    0      0      0      0   100%
imblearn/utils/tests/test_deprecation.py                                                           11      0      0      0   100%
imblearn/utils/tests/test_docstring.py                                                             18      3      0      0    83%   31, 55-56
imblearn/utils/tests/test_estimator_checks.py                                                      69      2      0      0    97%   58-59
imblearn/utils/tests/test_show_versions.py                                                         51      0      0      0   100%
imblearn/utils/tests/test_testing.py                                                               37      0      2      0   100%
imblearn/utils/tests/test_validation.py                                                           165      0      4      0   100%
-------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                                            5971    264   1021     56    95%

======================================================= short test summary info =======================================================
SKIPPED [2] imblearn/keras/tests/test_generator.py:8: could not import 'keras': No module named 'keras'
SKIPPED [2] imblearn/tensorflow/tests/test_generator.py:15: could not import 'tensorflow': No module named 'tensorflow'
SKIPPED [2] conftest.py:28: The keras package is not installed.
SKIPPED [1] ../../miniconda3/envs/imblearn-dev/lib/python3.7/site-packages/_pytest/doctest.py:448: all tests skipped by +SKIP option
=========================== 1987 passed, 7 skipped, 2 xfailed, 3 xpassed, 11 warnings in 195.53s (0:03:15) ============================

```

</details>