### PR TITLE
DOC avoid clipping axis name in example

### DIFF
--- a/examples/over-sampling/plot_shrinkage_effect.py
+++ b/examples/over-sampling/plot_shrinkage_effect.py
@@ -43,6 +43,7 @@ class_legend = ax.legend(*scatter.legend_elements(), loc="lower left", title="Cl
 ax.add_artist(class_legend)
 ax.set_xlabel("Feature #1")
 _ = ax.set_ylabel("Feature #2")
+plt.tight_layout()
 
 # %%
 # Now, we will use a :class:`~imblearn.over_sampling.RandomOverSampler` to
@@ -61,6 +62,7 @@ class_legend = ax.legend(*scatter.legend_elements(), loc="lower left", title="Cl
 ax.add_artist(class_legend)
 ax.set_xlabel("Feature #1")
 _ = ax.set_ylabel("Feature #2")
+plt.tight_layout()
 # %%
 # We observe that the minority samples are less transparent than the samples
 # from the majority class. Indeed, it is due to the fact that these samples
@@ -79,6 +81,7 @@ class_legend = ax.legend(*scatter.legend_elements(), loc="lower left", title="Cl
 ax.add_artist(class_legend)
 ax.set_xlabel("Feature #1")
 _ = ax.set_ylabel("Feature #2")
+plt.tight_layout()
 
 # %%
 # In this case, we see that the samples in the minority class are not
@@ -97,6 +100,7 @@ class_legend = ax.legend(*scatter.legend_elements(), loc="lower left", title="Cl
 ax.add_artist(class_legend)
 ax.set_xlabel("Feature #1")
 _ = ax.set_ylabel("Feature #2")
+plt.tight_layout()
 
 # %%
 # Increasing the value of `shrinkage` will disperse the new samples. Forcing
@@ -112,6 +116,7 @@ class_legend = ax.legend(*scatter.legend_elements(), loc="lower left", title="Cl
 ax.add_artist(class_legend)
 ax.set_xlabel("Feature #1")
 _ = ax.set_ylabel("Feature #2")
+plt.tight_layout()
 
 # %%
 # Therefore, the `shrinkage` is handy to manually tune the dispersion of the


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Solves #821 


#### What does this implement/fix? Explain your changes.
Fixes the cropped axis name by adding plt.tight_layout() exlicitly

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
