### PR TITLE
[WIP] expands code of instance hardness to loop over class probabilities

### DIFF
--- a/imblearn/under_sampling/_prototype_selection/_instance_hardness_threshold.py
+++ b/imblearn/under_sampling/_prototype_selection/_instance_hardness_threshold.py
@@ -15,6 +15,7 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.ensemble._base import _set_random_states
 from sklearn.model_selection import StratifiedKFold
 from sklearn.model_selection import cross_val_predict
+from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import check_random_state
 from sklearn.utils import _safe_indexing
 
@@ -153,20 +154,23 @@ class InstanceHardnessThreshold(BaseUnderSampler):
             n_jobs=self.n_jobs,
             method="predict_proba",
         )
-        probabilities = probabilities[range(len(y)), y]
+
+        # obtain order of the classes
+        le = LabelEncoder()
+        le.fit(y)
+        classes_ = list(le.classes_)
 
         idx_under = np.empty((0,), dtype=int)
 
         for target_class in np.unique(y):
             if target_class in self.sampling_strategy_.keys():
                 n_samples = self.sampling_strategy_[target_class]
+                probs = probabilities[y == target_class, classes_.index(target_class)]
                 threshold = np.percentile(
-                    probabilities[y == target_class],
+                    probs,
                     (1.0 - (n_samples / target_stats[target_class])) * 100.0,
                 )
-                index_target_class = np.flatnonzero(
-                    probabilities[y == target_class] >= threshold
-                )
+                index_target_class = np.flatnonzero(probs >= threshold)
             else:
                 index_target_class = slice(None)
 

--- a/imblearn/under_sampling/_prototype_selection/tests/test_instance_hardness_threshold.py
+++ b/imblearn/under_sampling/_prototype_selection/tests/test_instance_hardness_threshold.py
@@ -35,6 +35,7 @@ X = np.array(
     ]
 )
 Y = np.array([0, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0])
+Y_MULTI = np.array([0, 1, 1, 0, 1, 1, 2, 2, 1, 0, 1, 1, 0, 0, 0])
 ESTIMATOR = GradientBoostingClassifier(random_state=RND_SEED)
 
 
@@ -54,6 +55,10 @@ def test_iht_fit_resample():
     assert X_resampled.shape == (12, 2)
     assert y_resampled.shape == (12,)
 
+    X_resampled, y_resampled = iht.fit_resample(X, Y_MULTI)
+    assert X_resampled.shape == (6, 2)
+    assert y_resampled.shape == (6,)
+
 
 def test_iht_fit_resample_half():
     sampling_strategy = {0: 3, 1: 3}
@@ -63,6 +68,14 @@ def test_iht_fit_resample_half():
     X_resampled, y_resampled = iht.fit_resample(X, Y)
     assert X_resampled.shape == (6, 2)
     assert y_resampled.shape == (6,)
+
+    sampling_strategy = {0: 3, 1: 3, 2: 2}
+    iht = InstanceHardnessThreshold(
+        estimator=NB(), sampling_strategy=sampling_strategy, random_state=RND_SEED,
+    )
+    X_resampled, y_resampled = iht.fit_resample(X, Y_MULTI)
+    assert X_resampled.shape == (8, 2)
+    assert y_resampled.shape == (8,)
 
 
 def test_iht_fit_resample_class_obj():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
fixes #848 


#### What does this implement/fix? Explain your changes.
The instance hardness threshold uses the class probability to select instances that will be retained in the dataset. In the current implementation (I think), the transformer selects only the[ first vector of probability](https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/imblearn/under_sampling/_prototype_selection/_instance_hardness_threshold.py#L156). However, the instance hardness of each class depends on the probability of each class.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
