### PR TITLE
DOC use proper math symbol for subset

### DIFF
--- a/doc/under_sampling.rst
+++ b/doc/under_sampling.rst
@@ -63,7 +63,7 @@ Prototype selection
 
 On the contrary to prototype generation algorithms, prototype selection
 algorithms will select samples from the original set :math:`S`. Therefore,
-:math:`S'` is defined such as :math:`|S'| < |S|` and :math:`S' \in S`.
+:math:`S'` is defined such as :math:`|S'| < |S|` and :math:`S' \subset S`.
 
 In addition, these algorithms can be divided into two groups: (i) the
 controlled under-sampling techniques and (ii) the cleaning under-sampling


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
close #862 

#### What does this implement/fix? Explain your changes.
`\in` changed to `\subset` in `doc/under_sampling.rst` protype section.

P.n: I'm not sure which branch should I PR to but I think `master` is the best choice

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
