### PR TITLE
MAINT deprecate n_jobs in over-sampling algorithms

### DIFF
--- a/doc/whats_new/v0.10.rst
+++ b/doc/whats_new/v0.10.rst
@@ -6,6 +6,19 @@ Version 0.10.0 (ongoing)
 Changelog
 ---------
 
+Deprecation
+...........
+
+- The parameter `n_jobs` has been deprecated from the classes
+  :class:`~imblearn.over_sampling.ADASYN`,
+  :class:`~imblearn.over_sampling.BorderlineSMOTE`,
+  :class:`~imblearn.over_sampling.SMOTE`,
+  :class:`~imblearn.over_sampling.SMOTENC`,
+  :class:`~imblearn.over_sampling.SMOTEN`, and
+  :class:`~imblearn.over_sampling.SVMSMOTE`. Instead, pass a nearest neighbors
+  estimator where `n_jobs` is set.
+  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Enhancements
 ............
 

--- a/doc/whats_new/v0.10.rst
+++ b/doc/whats_new/v0.10.rst
@@ -17,7 +17,7 @@ Deprecation
   :class:`~imblearn.over_sampling.SMOTEN`, and
   :class:`~imblearn.over_sampling.SVMSMOTE`. Instead, pass a nearest neighbors
   estimator where `n_jobs` is set.
-  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`887` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 Enhancements
 ............

--- a/imblearn/over_sampling/_adasyn.py
+++ b/imblearn/over_sampling/_adasyn.py
@@ -4,6 +4,8 @@
 #          Christos Aridas
 # License: MIT
 
+import warnings
+
 import numpy as np
 from scipy import sparse
 
@@ -52,6 +54,12 @@ class ADASYN(BaseOverSampler):
           any compatible class.
 
     {n_jobs}
+
+        .. deprecated:: 0.10
+           `n_jobs` has been deprecated in 0.10 and will be removed in 0.12.
+           It was previously used to set `n_jobs` of nearest neighbors
+           algorithm. From now on, you can pass an estimator where `n_jobs` is
+           already set instead.
 
     Attributes
     ----------
@@ -133,6 +141,15 @@ ADASYN # doctest: +NORMALIZE_WHITESPACE
         )
 
     def _fit_resample(self, X, y):
+        # FIXME: to be removed in 0.12
+        if self.n_jobs is not None:
+            warnings.warn(
+                "The parameter `n_jobs` has been deprecated in 0.10 and will be "
+                "removed in 0.12. You can pass an nearest neighbors estimator where "
+                "`n_jobs` is already set instead.",
+                FutureWarning,
+            )
+
         self._validate_estimator()
         random_state = check_random_state(self.random_state)
 

--- a/imblearn/over_sampling/_smote/base.py
+++ b/imblearn/over_sampling/_smote/base.py
@@ -7,6 +7,7 @@
 # License: MIT
 
 import math
+import warnings
 from collections import Counter
 
 import numpy as np
@@ -238,6 +239,12 @@ class SMOTE(BaseSMOTE):
 
     {n_jobs}
 
+        .. deprecated:: 0.10
+           `n_jobs` has been deprecated in 0.10 and will be removed in 0.12.
+           It was previously used to set `n_jobs` of nearest neighbors
+           algorithm. From now on, you can pass an estimator where `n_jobs` is
+           already set instead.
+
     Attributes
     ----------
     sampling_strategy_ : dict
@@ -316,6 +323,15 @@ SMOTE # doctest: +NORMALIZE_WHITESPACE
         )
 
     def _fit_resample(self, X, y):
+        # FIXME: to be removed in 0.12
+        if self.n_jobs is not None:
+            warnings.warn(
+                "The parameter `n_jobs` has been deprecated in 0.10 and will be "
+                "removed in 0.12. You can pass an nearest neighbors estimator where "
+                "`n_jobs` is already set instead.",
+                FutureWarning,
+            )
+
         self._validate_estimator()
 
         X_resampled = [X.copy()]
@@ -387,6 +403,12 @@ class SMOTENC(SMOTE):
           any compatible class.
 
     {n_jobs}
+
+        .. deprecated:: 0.10
+           `n_jobs` has been deprecated in 0.10 and will be removed in 0.12.
+           It was previously used to set `n_jobs` of nearest neighbors
+           algorithm. From now on, you can pass an estimator where `n_jobs` is
+           already set instead.
 
     See Also
     --------
@@ -496,6 +518,15 @@ class SMOTENC(SMOTE):
             )
 
     def _fit_resample(self, X, y):
+        # FIXME: to be removed in 0.12
+        if self.n_jobs is not None:
+            warnings.warn(
+                "The parameter `n_jobs` has been deprecated in 0.10 and will be "
+                "removed in 0.12. You can pass an nearest neighbors estimator where "
+                "`n_jobs` is already set instead.",
+                FutureWarning,
+            )
+
         self.n_features_ = X.shape[1]
         self._validate_estimator()
 
@@ -636,7 +667,7 @@ class SMOTENC(SMOTE):
 class SMOTEN(SMOTE):
     """Synthetic Minority Over-sampling Technique for Nominal.
 
-    This method is refered as SMOTEN in [1]_. It expects that the data to
+    This method is referred as SMOTEN in [1]_. It expects that the data to
     resample are only made of categorical features.
 
     Read more in the :ref:`User Guide <smote_adasyn>`.
@@ -663,6 +694,12 @@ class SMOTEN(SMOTE):
           any compatible class.
 
     {n_jobs}
+
+        .. deprecated:: 0.10
+           `n_jobs` has been deprecated in 0.10 and will be removed in 0.12.
+           It was previously used to set `n_jobs` of nearest neighbors
+           algorithm. From now on, you can pass an estimator where `n_jobs` is
+           already set instead.
 
     Attributes
     ----------
@@ -755,6 +792,15 @@ class SMOTEN(SMOTE):
         return X_new, y_new
 
     def _fit_resample(self, X, y):
+        # FIXME: to be removed in 0.12
+        if self.n_jobs is not None:
+            warnings.warn(
+                "The parameter `n_jobs` has been deprecated in 0.10 and will be "
+                "removed in 0.12. You can pass an nearest neighbors estimator where "
+                "`n_jobs` is already set instead.",
+                FutureWarning,
+            )
+
         self._validate_estimator()
 
         X_resampled = [X.copy()]

--- a/imblearn/over_sampling/_smote/filter.py
+++ b/imblearn/over_sampling/_smote/filter.py
@@ -6,6 +6,8 @@
 #          Dzianis Dudnik
 # License: MIT
 
+import warnings
+
 import numpy as np
 from scipy import sparse
 
@@ -60,6 +62,12 @@ class BorderlineSMOTE(BaseSMOTE):
           any compatible class.
 
     {n_jobs}
+
+        .. deprecated:: 0.10
+           `n_jobs` has been deprecated in 0.10 and will be removed in 0.12.
+           It was previously used to set `n_jobs` of nearest neighbors
+           algorithm. From now on, you can pass an estimator where `n_jobs` is
+           already set instead.
 
     m_neighbors : int or object, default=10
         The nearest neighbors used to determine if a minority sample is in
@@ -176,6 +184,15 @@ BorderlineSMOTE # doctest: +NORMALIZE_WHITESPACE
             )
 
     def _fit_resample(self, X, y):
+        # FIXME: to be removed in 0.12
+        if self.n_jobs is not None:
+            warnings.warn(
+                "The parameter `n_jobs` has been deprecated in 0.10 and will be "
+                "removed in 0.12. You can pass an nearest neighbors estimator where "
+                "`n_jobs` is already set instead.",
+                FutureWarning,
+            )
+
         self._validate_estimator()
 
         X_resampled = X.copy()
@@ -288,6 +305,12 @@ class SVMSMOTE(BaseSMOTE):
           any compatible class.
 
     {n_jobs}
+
+        .. deprecated:: 0.10
+           `n_jobs` has been deprecated in 0.10 and will be removed in 0.12.
+           It was previously used to set `n_jobs` of nearest neighbors
+           algorithm. From now on, you can pass an estimator where `n_jobs` is
+           already set instead.
 
     m_neighbors : int or object, default=10
         The nearest neighbors used to determine if a minority sample is in
@@ -416,6 +439,15 @@ SVMSMOTE # doctest: +NORMALIZE_WHITESPACE
             self.svm_estimator_ = clone(self.svm_estimator)
 
     def _fit_resample(self, X, y):
+        # FIXME: to be removed in 0.12
+        if self.n_jobs is not None:
+            warnings.warn(
+                "The parameter `n_jobs` has been deprecated in 0.10 and will be "
+                "removed in 0.12. You can pass an nearest neighbors estimator where "
+                "`n_jobs` is already set instead.",
+                FutureWarning,
+            )
+
         self._validate_estimator()
         random_state = check_random_state(self.random_state)
         X_resampled = X.copy()

--- a/imblearn/over_sampling/tests/test_common.py
+++ b/imblearn/over_sampling/tests/test_common.py
@@ -116,3 +116,23 @@ def test_numerical_smote_extra_custom_nn(numerical_data, smote):
 
     assert X_res.shape == (120, 2)
     assert Counter(y_res) == {0: 60, 1: 60}
+
+
+# FIXME: to be removed in 0.12
+@pytest.mark.parametrize(
+    "sampler",
+    [
+        ADASYN(random_state=0),
+        BorderlineSMOTE(random_state=0),
+        SMOTE(random_state=0),
+        SMOTEN(random_state=0),
+        SMOTENC([0], random_state=0),
+        SVMSMOTE(random_state=0),
+    ],
+)
+def test_n_jobs_deprecation_warning(numerical_data, sampler):
+    X, y = numerical_data
+    sampler.set_params(n_jobs=2)
+    warning_msg = "The parameter `n_jobs` has been deprecated"
+    with pytest.warns(FutureWarning, match=warning_msg):
+        sampler.fit_resample(X, y)


### PR DESCRIPTION
Most of the time `n_jobs` is not used anymore. Currently it was really useful to use it in scikit-learn and it can be set directly by passing an estimator with the parameter set which is a better choice.