### PR TITLE
MAINT using keras from tensorflow to skip doctest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,15 +11,10 @@ import pytest
 
 def pytest_runtest_setup(item):
     fname = item.fspath.strpath
-    if fname.endswith(os.path.join("keras", "_generator.py")) or fname.endswith(
-        "miscellaneous.rst"
-    ):
-        try:
-            import keras  # noqa
-        except ImportError:
-            pytest.skip("The keras package is not installed.")
-    elif fname.endswith(os.path.join("tensorflow", "_generator.py")) or fname.endswith(
-        "miscellaneous.rst"
+    if (
+        fname.endswith(os.path.join("keras", "_generator.py"))
+        or fname.endswith(os.path.join("tensorflow", "_generator.py"))
+        or fname.endswith("miscellaneous.rst")
     ):
         try:
             import tensorflow  # noqa


### PR DESCRIPTION
The CI is failing because our documentation expects to use `keras` embedded in `tensorflow`.
Our doctest skipping is expecting to use directly keras.