### PR TITLE
[MRG] Fix SmoteNC zero variance resampling

### DIFF
--- a/imblearn/over_sampling/_smote/base.py
+++ b/imblearn/over_sampling/_smote/base.py
@@ -577,7 +577,9 @@ class SMOTENC(SMOTE):
             )
             # Store which row belongs to which class so we can subset in _generate_samples
             minority_y = y[y != class_majority]
-            self._X_categorical_class_to_index = {class_: np.flatnonzero(minority_y == class_) for class_ in target_stats}
+            self._X_categorical_class_to_index = {
+                class_: np.flatnonzero(minority_y == class_) for class_ in target_stats
+            }
 
         X_ohe.data = np.ones_like(X_ohe.data, dtype=X_ohe.dtype) * self.median_std_ / 2
         X_encoded = sparse.hstack((X_continuous, X_ohe), format="csr")
@@ -639,9 +641,10 @@ class SMOTENC(SMOTE):
         # In the case that the median std was equal to zeros, we have to
         # create non-null entry based on the encoded of OHE
         if math.isclose(self.median_std_, 0):
-            nn_data[
-                :, self.continuous_features_.size :
-            ] = _safe_indexing(self._X_categorical_minority_encoded, self._X_categorical_class_to_index[ytype])
+            nn_data[:, self.continuous_features_.size :] = _safe_indexing(
+                self._X_categorical_minority_encoded,
+                self._X_categorical_class_to_index[ytype],
+            )
 
         all_neighbors = nn_data[nn_num[rows]]
 

--- a/imblearn/over_sampling/_smote/base.py
+++ b/imblearn/over_sampling/_smote/base.py
@@ -575,7 +575,8 @@ class SMOTENC(SMOTE):
             self._X_categorical_minority_encoded = _safe_indexing(
                 X_ohe.toarray(), np.flatnonzero(y != class_majority)
             )
-            # Store which row belongs to which class so we can subset in _generate_samples
+            # Store which row belongs to which class so we can subset
+            # in _generate_samples
             minority_y = y[y != class_majority]
             self._X_categorical_class_to_index = {
                 class_: np.flatnonzero(minority_y == class_) for class_ in target_stats

--- a/imblearn/over_sampling/tests/test_common.py
+++ b/imblearn/over_sampling/tests/test_common.py
@@ -104,6 +104,20 @@ def test_heterogeneous_smote_k_custom_nn(heterogeneous_data):
     assert Counter(y_res) == {0: 20, 1: 20}
 
 
+def test_heterogeneous_zero_variance_data_smotenc():
+    X = np.empty((100, 4), dtype=object)
+    X[:, 0] = [5] * 100
+    X[:, 1] = [5] * 100
+    X[:, 2] = np.arange(100)
+    X[:, 3] = np.array(["a"] * 50 + ["b"] * 25 + ["c"] * 25, dtype=object)
+    y = np.array([0] * 80 + [1] * 11 + [2] * 9)
+    sampler = SMOTENC(categorical_features=[3],
+                      k_neighbors=5,
+                      sampling_strategy={0: 80, 1: 20, 2: 20})
+    X_res, y_res = sampler.fit_resample(X, y)
+    assert Counter(y_res) == {0: 80, 1: 20, 2: 20}
+
+
 @pytest.mark.parametrize(
     "smote",
     [BorderlineSMOTE(random_state=0), SVMSMOTE(random_state=0)],

--- a/imblearn/over_sampling/tests/test_common.py
+++ b/imblearn/over_sampling/tests/test_common.py
@@ -111,9 +111,9 @@ def test_heterogeneous_zero_variance_data_smotenc():
     X[:, 2] = np.arange(100)
     X[:, 3] = np.array(["a"] * 50 + ["b"] * 25 + ["c"] * 25, dtype=object)
     y = np.array([0] * 80 + [1] * 11 + [2] * 9)
-    sampler = SMOTENC(categorical_features=[3],
-                      k_neighbors=5,
-                      sampling_strategy={0: 80, 1: 20, 2: 20})
+    sampler = SMOTENC(
+        categorical_features=[3], k_neighbors=5, sampling_strategy={0: 80, 1: 20, 2: 20}
+    )
     X_res, y_res = sampler.fit_resample(X, y)
     assert Counter(y_res) == {0: 80, 1: 20, 2: 20}
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
Fixes #837 


#### What does this implement/fix? Explain your changes.

Fixes the issue as described by @glemaitre here: https://github.com/scikit-learn-contrib/imbalanced-learn/issues/837#issuecomment-1013928249

#### Any other comments?
Had to add `ytype` to base class `generate_samples` api in order to know which class we're resampling so we can use the right subset of `_X_categorical_minority_encoded`

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
