### PR TITLE
DOC Fix incorrect source code link

### DIFF
--- a/doc/sphinxext/github_link.py
+++ b/doc/sphinxext/github_link.py
@@ -40,11 +40,9 @@ def _linkcode_resolve(domain, info, package, url_fmt, revision):
         return
 
     class_name = info["fullname"].split(".")[0]
-    if type(class_name) != str:
-        # Python 2 only
-        class_name = class_name.encode("utf-8")
     module = __import__(info["module"], fromlist=[class_name])
     obj = attrgetter(info["fullname"])(module)
+    obj = inspect.unwrap(obj)
 
     try:
         fn = inspect.getsourcefile(obj)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
Some source code links are wrong in the API reference. For example [make_imbalance](https://imbalanced-learn.org/stable/references/generated/imblearn.datasets.make_imbalance.html), [fetch_datasets](https://imbalanced-learn.org/stable/references/generated/imblearn.datasets.fetch_datasets.html), [classification_report_imbalanced](https://imbalanced-learn.org/stable/references/generated/imblearn.metrics.classification_report_imbalanced.html) and many more. The common thing between those objects is they wrapped by a decorator.
Similar problem occurred in scikit-learn in the past. This [PR](https://github.com/scikit-learn/scikit-learn/pull/17247) fixed it. 
#### Any other comments?
As stated in the PR, I also dropped removed Python 2 related lines because Python 2 support is dropped in 0.5.0.
Also, source code links now points to the decorator.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
