### PR TITLE
[MRG] FIX Make pipeline.fit_transform behaves the same as fit().transform()

### DIFF
--- a/imblearn/pipeline.py
+++ b/imblearn/pipeline.py
@@ -301,16 +301,12 @@ class Pipeline(pipeline.Pipeline):
         """
         fit_params_steps = self._check_fit_params(**fit_params)
         Xt, yt = self._fit(X, y, **fit_params_steps)
-
-        last_step = self._final_estimator
         with _print_elapsed_time("Pipeline", self._log_message(len(self.steps) - 1)):
-            if last_step == "passthrough":
-                return Xt
-            fit_params_last_step = fit_params_steps[self.steps[-1][0]]
-            if hasattr(last_step, "fit_transform"):
-                return last_step.fit_transform(Xt, yt, **fit_params_last_step)
-            else:
-                return last_step.fit(Xt, yt, **fit_params_last_step).transform(Xt)
+            if self._final_estimator != "passthrough":
+                fit_params_last_step = fit_params_steps[self.steps[-1][0]]
+                self._final_estimator.fit(Xt, yt, **fit_params_last_step)
+                return self.transform(X)
+            return Xt
 
     def fit_resample(self, X, y=None, **fit_params):
         """Fit the model and sample with the final estimator.

--- a/imblearn/tests/test_pipeline.py
+++ b/imblearn/tests/test_pipeline.py
@@ -445,17 +445,22 @@ def test_pipeline_transform():
     assert_array_almost_equal(X_back, X_back2)
 
 
-def test_pipeline_fit_transform():
+@pytest.mark.parametrize(
+    "pipeline",
+    [
+        Pipeline([("mock", Transf())]),
+        Pipeline((("sampler", DummySampler()), ("mock", Transf()))),
+    ],
+)
+def test_pipeline_fit_transform(pipeline):
     # Test whether pipeline works with a transformer missing fit_transform
     iris = load_iris()
     X = iris.data
     y = iris.target
-    transf = Transf()
-    pipeline = Pipeline([("mock", transf)])
 
     # test fit_transform:
     X_trans = pipeline.fit_transform(X, y)
-    X_trans2 = transf.fit(X, y).transform(X)
+    X_trans2 = pipeline.fit(X, y).transform(X)
     assert_array_almost_equal(X_trans, X_trans2)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #904 

#### What does this implement/fix? Explain your changes.
* Change `pipeline.fit_transform` to fit final estimator with transformed data, then use fitted estimator to transform original data to skip samplers in the pipeline.
* Add test to test whether samplers in the pipeline are skipped during `transform`.

#### Any other comments?
* I think `fit().transform()` should behave the same as `fit_transform()`.
* I modified the behavior of `pipeline.fit_transform`, so it actually not using `fit_transform` from the final estimator. It will use `fit()` from final estimator and `pipeline.transform()`. This might need to update the documentation.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
