### PR TITLE
update error message to account for zero based indexing

### DIFF
--- a/imblearn/over_sampling/_smote/base.py
+++ b/imblearn/over_sampling/_smote/base.py
@@ -504,7 +504,7 @@ class SMOTENC(SMOTE):
             ):
                 raise ValueError(
                     f"Some of the categorical indices are out of range. Indices"
-                    f" should be between 0 and {self.n_features_}"
+                    f" should be between 0 and {self.n_features_ - 1}"
                 )
             self.categorical_features_ = categorical_features
         self.continuous_features_ = np.setdiff1d(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
N/A


#### What does this implement/fix? Explain your changes.
Value error in `_validate_estimator` method of `SMOTENC` class does not account for zero-based indexing. Subtracting 1 from n_features takes care of this. 


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
