### PR TITLE
FIX make sure we can execute code with python -OO

### DIFF
--- a/doc/whats_new/v0.10.rst
+++ b/doc/whats_new/v0.10.rst
@@ -6,6 +6,13 @@ Version 0.10.0 (ongoing)
 Changelog
 ---------
 
+Bug fixes
+.........
+
+- Make sure that :class:`~imblearn.utils._docstring.Substitution` is
+  working with `python -OO` that replace `__doc__` by `None`.
+  :pr:`xxx` bu :user:`Guillaume Lemaitre <glemaitre>`.
+
 Compatibility
 .............
 

--- a/doc/whats_new/v0.10.rst
+++ b/doc/whats_new/v0.10.rst
@@ -11,7 +11,7 @@ Bug fixes
 
 - Make sure that :class:`~imblearn.utils._docstring.Substitution` is
   working with `python -OO` that replace `__doc__` by `None`.
-  :pr:`xxx` bu :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`953` bu :user:`Guillaume Lemaitre <glemaitre>`.
 
 Compatibility
 .............

--- a/imblearn/utils/_docstring.py
+++ b/imblearn/utils/_docstring.py
@@ -19,7 +19,8 @@ class Substitution:
         self.params = args or kwargs
 
     def __call__(self, obj):
-        obj.__doc__ = obj.__doc__.format(**self.params)
+        if obj.__doc__:
+            obj.__doc__ = obj.__doc__.format(**self.params)
         return obj
 
 

--- a/imblearn/utils/tests/test_docstring.py
+++ b/imblearn/utils/tests/test_docstring.py
@@ -66,3 +66,17 @@ def test_docstring_inject(obj, obj_docstring):
 def test_docstring_template():
     assert "random_state" in _random_state_docstring
     assert "n_jobs" in _n_jobs_docstring
+
+
+def test_docstring_with_python_OO():
+    """Check that we don't raise a warning if the code is executed with -OO.
+
+    Non-regression test for:
+    https://github.com/scikit-learn-contrib/imbalanced-learn/issues/945
+    """
+    instance = cls(param_1="xxx", param_2="yyy")
+    instance.__doc__ = None  # simulate -OO
+
+    instance = Substitution(param_1="xxx", param_2="yyy")(instance)
+
+    assert instance.__doc__ is None


### PR DESCRIPTION
closes #945 

Make sure we can execute code with `python -OO`.
It implies that the docstring ingestion should not fail.