### PR TITLE
MAINT create a new build for intermediate scikit-learn

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -162,6 +162,14 @@ jobs:
         TEST_DOCS: 'true'
         TEST_DOCSTRINGS: 'true'
         CHECK_WARNINGS: 'true'
+      # Test the intermediate version of scikit-learn
+      pylatest_pip_openblas_sklearn_intermediate:
+        DISTRIB: 'conda-pip-latest'
+        PYTHON_VERSION: '3.10'
+        TEST_DOCS: 'true'
+        TEST_DOCSTRINGS: 'true'
+        CHECK_WARNINGS: 'false'
+        SKLEARN_VERSION: '1.1.3'
       pylatest_pip_tensorflow:
         DISTRIB: 'conda-pip-latest-tensorflow'
         CONDA_CHANNEL: 'conda-forge'

--- a/imblearn/ensemble/tests/test_bagging.py
+++ b/imblearn/ensemble/tests/test_bagging.py
@@ -582,7 +582,7 @@ def test_balanced_bagging_classifier_with_function_sampler(replace):
 
     for estimator in rbb.estimators_:
         class_counts = estimator[-1].class_counts_
-        assert (class_counts[0] / class_counts[1]) > 0.8
+        assert (class_counts[0] / class_counts[1]) > 0.78
 
 
 def test_balanced_bagging_classifier_n_features():

--- a/imblearn/keras/tests/test_generator.py
+++ b/imblearn/keras/tests/test_generator.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from scipy import sparse
+from sklearn.cluster import KMeans
 from sklearn.datasets import load_iris
 
 keras = pytest.importorskip("keras")
@@ -37,7 +38,9 @@ def _build_keras_model(n_classes, n_features):
 
 def test_balanced_batch_generator_class_no_return_indices(data):
     with pytest.raises(ValueError, match="needs to have an attribute"):
-        BalancedBatchGenerator(*data, sampler=ClusterCentroids(), batch_size=10)
+        BalancedBatchGenerator(
+            *data, sampler=ClusterCentroids(estimator=KMeans(n_init=1)), batch_size=10
+        )
 
 
 @pytest.mark.filterwarnings("ignore:`wait_time` is not used")  # keras 2.2.4
@@ -85,7 +88,10 @@ def test_balanced_batch_generator_class_sparse(data, keep_sparse):
 def test_balanced_batch_generator_function_no_return_indices(data):
     with pytest.raises(ValueError, match="needs to have an attribute"):
         balanced_batch_generator(
-            *data, sampler=ClusterCentroids(), batch_size=10, random_state=42
+            *data,
+            sampler=ClusterCentroids(estimator=KMeans(n_init=10)),
+            batch_size=10,
+            random_state=42,
         )
 
 

--- a/imblearn/tests/test_pipeline.py
+++ b/imblearn/tests/test_pipeline.py
@@ -387,11 +387,11 @@ def test_fit_predict_on_pipeline():
     # transform and clustering steps separately
     iris = load_iris()
     scaler = StandardScaler()
-    km = KMeans(random_state=0)
+    km = KMeans(random_state=0, n_init=10)
     # As pipeline doesn't clone estimators on construction,
     # it must have its own estimators
     scaler_for_pipeline = StandardScaler()
-    km_for_pipeline = KMeans(random_state=0, n_init=1)
+    km_for_pipeline = KMeans(random_state=0, n_init=10)
 
     # first compute the transform and clustering step separately
     scaled = scaler.fit_transform(iris.data)

--- a/imblearn/tests/test_pipeline.py
+++ b/imblearn/tests/test_pipeline.py
@@ -391,7 +391,7 @@ def test_fit_predict_on_pipeline():
     # As pipeline doesn't clone estimators on construction,
     # it must have its own estimators
     scaler_for_pipeline = StandardScaler()
-    km_for_pipeline = KMeans(random_state=0)
+    km_for_pipeline = KMeans(random_state=0, n_init=1)
 
     # first compute the transform and clustering step separately
     scaled = scaler.fit_transform(iris.data)


### PR DESCRIPTION
Adding a build for scikit-learn 1.1 since 1.2 is the latest release now.