### PR TITLE
Fixed CircleCI badge in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@
 .. |Codecov| image:: https://codecov.io/gh/scikit-learn-contrib/imbalanced-learn/branch/master/graph/badge.svg
 .. _Codecov: https://codecov.io/gh/scikit-learn-contrib/imbalanced-learn
 
-.. |CircleCI| image:: https://circleci.com/gh/scikit-learn-contrib/imbalanced-learn.svg?style=shield&circle-token=:circle-token
+.. |CircleCI| image:: https://circleci.com/gh/scikit-learn-contrib/imbalanced-learn.svg?style=shield
 .. _CircleCI: https://circleci.com/gh/scikit-learn-contrib/imbalanced-learn/tree/master
 
 .. |PythonVersion| image:: https://img.shields.io/pypi/pyversions/imbalanced-learn.svg


### PR DESCRIPTION
Originally the badges look like this:

![image](https://user-images.githubusercontent.com/108576690/232149996-5f3d435b-ddf7-4b36-b75a-189bb95a2f28.png)

As you can see, the CircleCI badge is broken. It doesn't seem that `token` is needed for the badge. This is similar to https://github.com/scikit-learn/scikit-learn/pull/26183