### PR TITLE
[MRG] Fix AttributeError in Sequential object - predict_proba

### DIFF
--- a/examples/applications/porto_seguro_keras_under_sampling.py
+++ b/examples/applications/porto_seguro_keras_under_sampling.py
@@ -149,15 +149,23 @@ def timeit(f):
 ###############################################################################
 # The first model will be trained using the ``fit`` method and with imbalanced
 # mini-batches.
-
+import tensorflow
 from sklearn.metrics import roc_auc_score
+from sklearn.utils import parse_version
+
+tf_version = parse_version(tensorflow.__version__)
 
 
 @timeit
 def fit_predict_imbalanced_model(X_train, y_train, X_test, y_test):
     model = make_model(X_train.shape[1])
     model.fit(X_train, y_train, epochs=2, verbose=1, batch_size=1000)
-    y_pred = model.predict(X_test, batch_size=1000)
+    if tf_version < parse_version("2.6"):
+        # predict_proba was removed in tensorflow 2.6
+        predict_method = "predict_proba"
+    else:
+        predict_method = "predict"
+    y_pred = getattr(model, predict_method)(X_test, batch_size=1000)
     return roc_auc_score(y_test, y_pred)
 
 

--- a/examples/applications/porto_seguro_keras_under_sampling.py
+++ b/examples/applications/porto_seguro_keras_under_sampling.py
@@ -157,7 +157,7 @@ from sklearn.metrics import roc_auc_score
 def fit_predict_imbalanced_model(X_train, y_train, X_test, y_test):
     model = make_model(X_train.shape[1])
     model.fit(X_train, y_train, epochs=2, verbose=1, batch_size=1000)
-    y_pred = model.predict_proba(X_test, batch_size=1000)
+    y_pred = model.predict(X_test, batch_size=1000)
     return roc_auc_score(y_test, y_pred)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
N/A

#### What does this implement/fix? Explain your changes.

This pull request fixes an AttributeError in the Sequential object when using the `predict_proba` method. The Sequential class in TensorFlow does not have a `predict_proba` method. Instead, it has been deprecated in favour of the `predict` method, which directly returns the predicted class probabilities.

#### Any other comments?

N/A

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
