### PR TITLE
Fix sklearn v1.3 Import for MissingValues

### DIFF
--- a/imblearn/utils/_param_validation.py
+++ b/imblearn/utils/_param_validation.py
@@ -917,7 +917,6 @@ else:
         _CVObjects,
         _InstancesOf,
         _IterablesNotString,
-        _MissingValues,
         _NoneConstraint,
         _PandasNAConstraint,
         _RandomStates,
@@ -926,3 +925,8 @@ else:
         make_constraint,
         validate_params,
     )
+
+    if sklearn_version < parse_version("1.3"):
+        from sklearn.utils._param_validation import _MissingValues
+    else:
+        from sklearn.utils._param_validation import MissingValues as _MissingValues


### PR DESCRIPTION
Fixes #995
Fixes #996
Closes #997

#### What does this implement/fix? Explain your changes.
This PR fixes the import of ``sklearn.utils._param_validation._MissingValues`` in version 1.3 of ``sklearn``. The underscore has been removed; so from version 1.3 it is ``sklearn.utils._param_validation.MissingValues`` (see https://github.com/scikit-learn/scikit-learn/discussions/26774). Following the current logic in ``imblearn.utils._param_validation``, the version of ``sklearn`` is checked and the import handled based on the installed version. Which is much better than simply removing the import as suggested by #997.

#### Any other comments?
#987 suggested to set the minimum version of ``sklearn`` to 1.2.1. I agree with the suggestion. It seems that by implementing said PR, only the above mentioned import needs to be handled differently based on the installed version of ``sklearn``, i.e., either 1.2 or 1.3.