### PR TITLE
ENH add categorical_encoder to SMOTEN

### DIFF
--- a/doc/whats_new/v0.11.rst
+++ b/doc/whats_new/v0.11.rst
@@ -20,6 +20,12 @@ Enhancements
   parameters.
   :pr:`1000` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- :class:`~imblearn.over_sampling.SMOTEN` now accepts a parameter `categorical_encoder`
+  allowing to specify a :class:`~sklearn.preprocessing.OrdinalEncoder` with custom
+  parameters. A new fitted parameter `categorical_encoder_` is exposed to access the
+  fitted encoder.
+  :pr:`1001` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Deprecation
 ...........
 

--- a/imblearn/over_sampling/_smote/tests/test_smoten.py
+++ b/imblearn/over_sampling/_smote/tests/test_smoten.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from sklearn.preprocessing import OrdinalEncoder
 
 from imblearn.over_sampling import SMOTEN
 
@@ -27,6 +28,7 @@ def test_smoten(data):
 
     assert X_res.shape == (80, 3)
     assert y_res.shape == (80,)
+    assert isinstance(sampler.categorical_encoder_, OrdinalEncoder)
 
 
 def test_smoten_resampling():
@@ -52,3 +54,22 @@ def test_smoten_resampling():
     X_generated, y_generated = X_res[X.shape[0] :], y_res[X.shape[0] :]
     np.testing.assert_array_equal(X_generated, "blue")
     np.testing.assert_array_equal(y_generated, "not apple")
+
+
+def test_smoten_categorical_encoder(data):
+    """Check that `categorical_encoder` is used when provided."""
+
+    X, y = data
+    sampler = SMOTEN(random_state=0)
+    sampler.fit_resample(X, y)
+
+    assert isinstance(sampler.categorical_encoder_, OrdinalEncoder)
+    assert sampler.categorical_encoder_.dtype == np.int32
+
+    encoder = OrdinalEncoder(dtype=np.int64)
+    sampler.set_params(categorical_encoder=encoder).fit_resample(X, y)
+
+    assert isinstance(sampler.categorical_encoder_, OrdinalEncoder)
+    assert sampler.categorical_encoder is encoder
+    assert sampler.categorical_encoder_ is not encoder
+    assert sampler.categorical_encoder_.dtype == np.int64


### PR DESCRIPTION
Add a new parameter `categorical_encoder` to `SMOTEN`.
Additionally, there is a new `categorical_encoder_` as a fitted attribute.