### PR TITLE
FIX handle heterogeneous data type in categorical feature in SMOTENC

### DIFF
--- a/doc/whats_new/v0.11.rst
+++ b/doc/whats_new/v0.11.rst
@@ -6,11 +6,25 @@ Version 0.11.0 (Under development)
 Changelog
 ---------
 
+Bug fixes
+.........
+
+- :class:`~imblearn.over_sampling.SMOTENC` now handles mix types of data type such as
+  `bool` and `pd.category` by delegating the conversion to scikit-learn encoder.
+  :pr:`1002` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Compatibility
 .............
 
 - Maintenance release for being compatible with scikit-learn >= 1.3.0.
   :pr:`999` by :user:`Guillaume Lemaitre <glemaitre>`.
+
+Deprecation
+...........
+
+- The fitted attribute `ohe_` in :class:`~imblearn.over_sampling.SMOTENC` is deprecated
+  and will be removed in version 0.13. Use `categorical_encoder_` instead.
+  :pr:`1000` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 Enhancements
 ............
@@ -18,11 +32,4 @@ Enhancements
 - :class:`~imblearn.over_sampling.SMOTENC` now accepts a parameter `categorical_encoder`
   allowing to specify a :class:`~sklearn.preprocessing.OneHotEncoder` with custom
   parameters.
-  :pr:`1000` by :user:`Guillaume Lemaitre <glemaitre>`.
-
-Deprecation
-...........
-
-- The fitted attribute `ohe_` in :class:`~imblearn.over_sampling.SMOTENC` is deprecated
-  and will be removed in version 0.13. Use `categorical_encoder_` instead.
   :pr:`1000` by :user:`Guillaume Lemaitre <glemaitre>`.

--- a/imblearn/over_sampling/_smote/tests/test_smote_nc.py
+++ b/imblearn/over_sampling/_smote/tests/test_smote_nc.py
@@ -320,6 +320,7 @@ def test_smotenc_bool_categorical():
     pd.testing.assert_series_equal(X_res.dtypes, X.dtypes)
     assert len(X_res) == len(y_res)
 
-    X_res, y_res = smote.fit_resample(X.astype({"b": "category"}), y)
+    X = X.astype({"b": "category"})
+    X_res, y_res = smote.fit_resample(X, y)
     pd.testing.assert_series_equal(X_res.dtypes, X.dtypes)
     assert len(X_res) == len(y_res)

--- a/imblearn/over_sampling/_smote/tests/test_smote_nc.py
+++ b/imblearn/over_sampling/_smote/tests/test_smote_nc.py
@@ -290,3 +290,36 @@ def test_smotenc_param_validation():
     name = smote.__class__.__name__
     _set_checking_parameters(smote)
     check_param_validation(name, smote)
+
+
+def test_smotenc_bool_categorical():
+    """Check that we don't try to early convert the full input data to numeric when
+    handling a pandas dataframe.
+
+    Non-regression test for:
+    https://github.com/scikit-learn-contrib/imbalanced-learn/issues/974
+    """
+    pd = pytest.importorskip("pandas")
+
+    X = pd.DataFrame(
+        {
+            "c": pd.Categorical([x for x in "abbacaba" * 3]),
+            "f": [0.3, 0.5, 0.1, 0.2] * 6,
+            "b": [False, False, True] * 8,
+        }
+    )
+    y = pd.DataFrame({"out": [1, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0] * 2})
+    smote = SMOTENC(categorical_features=[0])
+
+    X_res, y_res = smote.fit_resample(X, y)
+    pd.testing.assert_series_equal(X_res.dtypes, X.dtypes)
+    assert len(X_res) == len(y_res)
+
+    smote.set_params(categorical_features=[0, 2])
+    X_res, y_res = smote.fit_resample(X, y)
+    pd.testing.assert_series_equal(X_res.dtypes, X.dtypes)
+    assert len(X_res) == len(y_res)
+
+    X_res, y_res = smote.fit_resample(X.astype({"b": "category"}), y)
+    pd.testing.assert_series_equal(X_res.dtypes, X.dtypes)
+    assert len(X_res) == len(y_res)


### PR DESCRIPTION
closes #974 

We previously validated the entire input data and try to convert all features to numerical values. Now, we first split the input data into two sets and only convert to numerical, the continuous feature and keep the data as-is and delegate the conversion to the scikit-learn encoder.