### PR TITLE
ENH support array-like of str for categorical_features in SMOTENC

### DIFF
--- a/doc/over_sampling.rst
+++ b/doc/over_sampling.rst
@@ -192,8 +192,8 @@ which categorical data are treated differently::
 
 In this data set, the first and last features are considered as categorical
 features. One needs to provide this information to :class:`SMOTENC` via the
-parameters ``categorical_features`` either by passing the indices of these
-features or a boolean mask marking these features::
+parameters ``categorical_features`` either by passing the indices, the feature
+names when `X` is a pandas DataFrame, or a boolean mask marking these features::
 
   >>> from imblearn.over_sampling import SMOTENC
   >>> smote_nc = SMOTENC(categorical_features=[0, 2], random_state=0)

--- a/doc/whats_new/v0.11.rst
+++ b/doc/whats_new/v0.11.rst
@@ -56,4 +56,4 @@ Enhancements
 
 - :class:`~imblearn.over_sampling.SMOTENC` now support passing array-like of `str`
   when passing the `categorical_features` parameter.
-  :pr:`1007` by :user`Guillaume Lemaitre <glemaitre>`.
+  :pr:`1008` by :user`Guillaume Lemaitre <glemaitre>`.

--- a/doc/whats_new/v0.11.rst
+++ b/doc/whats_new/v0.11.rst
@@ -53,3 +53,7 @@ Enhancements
   :class:`~imblearn.over_sampling.RandomOverSampler` (when `shrinkage is not
   None`) now accept any data types and will not attempt any data conversion.
   :pr:`1004` by :user:`Guillaume Lemaitre <glemaitre>`.
+
+- :class:`~imblearn.over_sampling.SMOTENC` now support passing array-like of `str`
+  when passing the `categorical_features` parameter.
+  :pr:`1007` by :user`Guillaume Lemaitre <glemaitre>`.


### PR DESCRIPTION
Make it possible to pass an array-like of `str` as a parameter of `categorical_features` for `SMOTENC`.