### PR TITLE
ENH add auto inference based on pd.CategoricalDtype in SMOTENC

### DIFF
--- a/doc/over_sampling.rst
+++ b/doc/over_sampling.rst
@@ -193,7 +193,9 @@ which categorical data are treated differently::
 In this data set, the first and last features are considered as categorical
 features. One needs to provide this information to :class:`SMOTENC` via the
 parameters ``categorical_features`` either by passing the indices, the feature
-names when `X` is a pandas DataFrame, or a boolean mask marking these features::
+names when `X` is a pandas DataFrame, a boolean mask marking these features,
+or relying on `dtype` inference if the columns are using the
+:class:`pandas.CategoricalDtype`::
 
   >>> from imblearn.over_sampling import SMOTENC
   >>> smote_nc = SMOTENC(categorical_features=[0, 2], random_state=0)

--- a/doc/over_sampling.rst
+++ b/doc/over_sampling.rst
@@ -192,8 +192,8 @@ which categorical data are treated differently::
 
 In this data set, the first and last features are considered as categorical
 features. One needs to provide this information to :class:`SMOTENC` via the
-parameters ``categorical_features`` either by passing the indices of these
-features or a boolean mask marking these features::
+parameters ``categorical_features`` either by passing the indices, the feature
+names when `X` is a pandas DataFrame, or a boolean mask marking these features::
 
   >>> from imblearn.over_sampling import SMOTENC
   >>> smote_nc = SMOTENC(categorical_features=[0, 2], random_state=0)

--- a/doc/whats_new/v0.11.rst
+++ b/doc/whats_new/v0.11.rst
@@ -56,4 +56,4 @@ Enhancements
 
 - :class:`~imblearn.over_sampling.SMOTENC` now support passing array-like of `str`
   when passing the `categorical_features` parameter.
-  :pr:`1007` by :user`Guillaume Lemaitre <glemaitre>`.
+  :pr:`1008` by :user`Guillaume Lemaitre <glemaitre>`.

--- a/doc/whats_new/v0.11.rst
+++ b/doc/whats_new/v0.11.rst
@@ -61,3 +61,7 @@ Enhancements
 - :class:`~imblearn.over_sampling.SMOTENC` now support passing array-like of `str`
   when passing the `categorical_features` parameter.
   :pr:`1008` by :user`Guillaume Lemaitre <glemaitre>`.
+
+- :class:`~imblearn.over_sampling.SMOTENC` now support automatic categorical inference
+  when `categorical_features` is set to `"auto"`.
+  :pr:`1009` by :user`Guillaume Lemaitre <glemaitre>`.

--- a/doc/whats_new/v0.11.rst
+++ b/doc/whats_new/v0.11.rst
@@ -53,3 +53,7 @@ Enhancements
   :class:`~imblearn.over_sampling.RandomOverSampler` (when `shrinkage is not
   None`) now accept any data types and will not attempt any data conversion.
   :pr:`1004` by :user:`Guillaume Lemaitre <glemaitre>`.
+
+- :class:`~imblearn.over_sampling.SMOTENC` now support passing array-like of `str`
+  when passing the `categorical_features` parameter.
+  :pr:`1007` by :user`Guillaume Lemaitre <glemaitre>`.

--- a/imblearn/over_sampling/_smote/base.py
+++ b/imblearn/over_sampling/_smote/base.py
@@ -395,7 +395,6 @@ class SMOTENC(SMOTE):
 
     Parameters
     ----------
-<<<<<<< HEAD
     categorical_features : "infer" or array-like of shape (n_cat_features,) or \
             (n_features,), dtype={{bool, int, str}}
         Specified which features are categorical. Can either be:
@@ -403,12 +402,6 @@ class SMOTENC(SMOTE):
         - "auto" (default) to automatically detect categorical features. Only
           supported when `X` is a :class:`pandas.DataFrame` and it corresponds
           to columns that have a :class:`pandas.CategoricalDtype`;
-=======
-    categorical_features : array-like of shape (n_cat_features,) or (n_features,), \
-            dtype={{bool, int, str}}
-        Specified which features are categorical. Can either be:
-
->>>>>>> origin/master
         - array of `int` corresponding to the indices specifying the categorical
           features;
         - array of `str` corresponding to the feature names. `X` should be a pandas


### PR DESCRIPTION
Add the option `categorical_features="auto"` that detects categorical features if they are using `pd.CategoricalDtype` in `SMOTENC` estimator.

In addition, we need to make sure that we don't only have numerical features after the inference, in which case, we raise an error.