### PR TITLE
API deprecate estimator_ in favor of estimators_ in CNN and OSS

### DIFF
--- a/doc/whats_new/v0.12.rst
+++ b/doc/whats_new/v0.12.rst
@@ -3,6 +3,14 @@
 Version 0.12.0 (Under development)
 ==================================
 
-
 Changelog
 ---------
+
+Deprecations
+............
+
+- Deprecate `estimator_` argument in favor of `estimators_` for the classes
+  :class:`~imblearn.under_sampling.CondensedNearestNeighbour` and
+  :class:`~imblearn.under_sampling.OneSidedSelection`. `estimator_` will be removed
+  in 0.14.
+  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.

--- a/imblearn/under_sampling/_prototype_selection/_one_sided_selection.py
+++ b/imblearn/under_sampling/_prototype_selection/_one_sided_selection.py
@@ -58,6 +58,12 @@ class OneSidedSelection(BaseCleaningSampler):
     estimator_ : estimator object
         Validated K-nearest neighbors estimator created from parameter `n_neighbors`.
 
+        .. deprecated:: 0.11
+           Should be remove
+
+    estimators_ : list of estimator objects of shape (n_resampled_classes - 1,)
+        Contains the K-nearest neighbor estimator used for per of classes.
+
     sample_indices_ : ndarray of shape (n_new_samples,)
         Indices of the samples selected.
 
@@ -155,6 +161,7 @@ class OneSidedSelection(BaseCleaningSampler):
 
         idx_under = np.empty((0,), dtype=int)
 
+        self.estimators_ = []
         for target_class in np.unique(y):
             if target_class in self.sampling_strategy_.keys():
                 # select a sample from the current class
@@ -177,8 +184,8 @@ class OneSidedSelection(BaseCleaningSampler):
                 idx_maj_extracted = np.delete(idx_maj, sel_idx_maj, axis=0)
                 S_x = _safe_indexing(X, idx_maj_extracted)
                 S_y = _safe_indexing(y, idx_maj_extracted)
-                self.estimator_.fit(C_x, C_y)
-                pred_S_y = self.estimator_.predict(S_x)
+                self.estimators_.append(clone(self.estimator_).fit(C_x, C_y))
+                pred_S_y = self.estimators_[-1].predict(S_x)
 
                 S_misclassified_indices = np.flatnonzero(pred_S_y != S_y)
                 idx_tmp = idx_maj_extracted[S_misclassified_indices]

--- a/imblearn/under_sampling/_prototype_selection/tests/test_condensed_nearest_neighbour.py
+++ b/imblearn/under_sampling/_prototype_selection/tests/test_condensed_nearest_neighbour.py
@@ -99,6 +99,7 @@ def test_cnn_fit_resample_with_object(n_neighbors):
 
 
 def test_condensed_nearest_neighbour_multiclass():
+    """Check the validity of the fitted attributes `estimators_`."""
     X, y = make_classification(
         n_samples=1_000,
         n_classes=4,
@@ -116,3 +117,13 @@ def test_condensed_nearest_neighbour_multiclass():
         assert est.classes_[1] in {1, 2, 3}  # other classes
         other_classes.append(est.classes_[1])
     assert len(set(other_classes)) == len(other_classes)
+
+
+# TODO: remove in 0.14
+def test_condensed_nearest_neighbors_deprecation():
+    """Check that we raise a FutureWarning when accessing the parameter `estimator_`."""
+    cnn = CondensedNearestNeighbour(random_state=RND_SEED)
+    cnn.fit_resample(X, Y)
+    warn_msg = "`estimator_` attribute has been deprecated"
+    with pytest.warns(FutureWarning, match=warn_msg):
+        cnn.estimator_

--- a/imblearn/under_sampling/_prototype_selection/tests/test_condensed_nearest_neighbour.py
+++ b/imblearn/under_sampling/_prototype_selection/tests/test_condensed_nearest_neighbour.py
@@ -5,6 +5,7 @@
 
 import numpy as np
 import pytest
+from sklearn.datasets import make_classification
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.utils._testing import assert_array_equal
 
@@ -95,3 +96,23 @@ def test_cnn_fit_resample_with_object(n_neighbors):
     X_resampled, y_resampled = cnn.fit_resample(X, Y)
     assert_array_equal(X_resampled, X_gt)
     assert_array_equal(y_resampled, y_gt)
+
+
+def test_condensed_nearest_neighbour_multiclass():
+    X, y = make_classification(
+        n_samples=1_000,
+        n_classes=4,
+        weights=[0.1, 0.2, 0.2, 0.5],
+        n_clusters_per_class=1,
+        random_state=0,
+    )
+    cnn = CondensedNearestNeighbour(random_state=RND_SEED)
+    cnn.fit_resample(X, y)
+
+    assert len(cnn.estimators_) == len(cnn.sampling_strategy_)
+    other_classes = []
+    for est in cnn.estimators_:
+        assert est.classes_[0] == 0  # minority class
+        assert est.classes_[1] in {1, 2, 3}  # other classes
+        other_classes.append(est.classes_[1])
+    assert len(set(other_classes)) == len(other_classes)


### PR DESCRIPTION
closes #908 

We should make sure that the documentation mentions the one-vs.-other strategy (wrong for CNN). Then it makes sense to store all pairs of k-NN instead of the last one from the loop.
We can then deprecate `estimator_` and create a new `estimators_` attribute.