### PR TITLE
FIX/DEPR follow literature for the implementation of NCR

### DIFF
--- a/doc/under_sampling.rst
+++ b/doc/under_sampling.rst
@@ -353,10 +353,10 @@ union of samples to be rejected between the :class:`EditedNearestNeighbours`
 and the output a 3 nearest neighbors classifier. The class can be used as::
 
   >>> from imblearn.under_sampling import NeighbourhoodCleaningRule
-  >>> ncr = NeighbourhoodCleaningRule()
+  >>> ncr = NeighbourhoodCleaningRule(n_neighbors=11)
   >>> X_resampled, y_resampled = ncr.fit_resample(X, y)
   >>> print(sorted(Counter(y_resampled).items()))
-  [(0, 64), (1, 234), (2, 4666)]
+  [(0, 64), (1, 193), (2, 4535)]
 
 .. image:: ./auto_examples/under-sampling/images/sphx_glr_plot_comparison_under_sampling_005.png
    :target: ./auto_examples/under-sampling/plot_comparison_under_sampling.html

--- a/doc/whats_new/v0.12.rst
+++ b/doc/whats_new/v0.12.rst
@@ -6,6 +6,18 @@ Version 0.12.0 (Under development)
 Changelog
 ---------
 
+Bug fixes
+.........
+
+- Fix a bug in :class:`~imblearn.under_sampling.NeighbourhoodCleaningRule` where the
+  `kind_sel="all"` was not working as explained in the literature.
+  :pr:`1012` by :user:`Guillaume Lemaitre <glemaitre>`.
+
+- Fix a bug in :class:`~imblearn.under_sampling.NeighbourhoodCleaningRule` where the
+  `threshold_cleaning` ratio was multiplied on the total number of samples instead of
+  the number of samples in the minority class.
+  :pr:`1012` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Deprecations
 ............
 
@@ -13,4 +25,8 @@ Deprecations
   :class:`~imblearn.under_sampling.CondensedNearestNeighbour` and
   :class:`~imblearn.under_sampling.OneSidedSelection`. `estimator_` will be removed
   in 0.14.
-  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`1011` by :user:`Guillaume Lemaitre <glemaitre>`.
+
+- Deprecate `kind_sel` in :class:`~imblearn.under_sampling.NeighbourhoodCleaningRule.
+  It will be removed in 0.14. The parameter does not have any effect.
+  :pr:`1012` by :user:`Guillaume Lemaitre <glemaitre>`.

--- a/examples/under-sampling/plot_comparison_under_sampling.py
+++ b/examples/under-sampling/plot_comparison_under_sampling.py
@@ -264,7 +264,7 @@ fig, axs = plt.subplots(nrows=3, ncols=2, figsize=(15, 25))
 samplers = [
     CondensedNearestNeighbour(random_state=0),
     OneSidedSelection(random_state=0),
-    NeighbourhoodCleaningRule(),
+    NeighbourhoodCleaningRule(n_neighbors=11),
 ]
 
 for ax, sampler in zip(axs, samplers):

--- a/imblearn/under_sampling/_prototype_selection/tests/test_neighbourhood_cleaning_rule.py
+++ b/imblearn/under_sampling/_prototype_selection/tests/test_neighbourhood_cleaning_rule.py
@@ -3,74 +3,82 @@
 #          Christos Aridas
 # License: MIT
 
+from collections import Counter
+
 import numpy as np
+import pytest
+from sklearn.datasets import make_classification
 from sklearn.utils._testing import assert_array_equal
 
-from imblearn.under_sampling import NeighbourhoodCleaningRule
-
-X = np.array(
-    [
-        [1.57737838, 0.1997882],
-        [0.8960075, 0.46130762],
-        [0.34096173, 0.50947647],
-        [-0.91735824, 0.93110278],
-        [-0.14619583, 1.33009918],
-        [-0.20413357, 0.64628718],
-        [0.85713638, 0.91069295],
-        [0.35967591, 2.61186964],
-        [0.43142011, 0.52323596],
-        [0.90701028, -0.57636928],
-        [-1.20809175, -1.49917302],
-        [-0.60497017, -0.66630228],
-        [1.39272351, -0.51631728],
-        [-1.55581933, 1.09609604],
-        [1.55157493, -1.6981518],
-    ]
-)
-Y = np.array([1, 2, 1, 1, 2, 1, 2, 2, 1, 2, 0, 0, 2, 1, 2])
+from imblearn.under_sampling import EditedNearestNeighbours, NeighbourhoodCleaningRule
 
 
-def test_ncr_fit_resample():
-    ncr = NeighbourhoodCleaningRule()
-    X_resampled, y_resampled = ncr.fit_resample(X, Y)
-
-    X_gt = np.array(
-        [
-            [0.34096173, 0.50947647],
-            [-0.91735824, 0.93110278],
-            [-0.20413357, 0.64628718],
-            [0.35967591, 2.61186964],
-            [0.90701028, -0.57636928],
-            [-1.20809175, -1.49917302],
-            [-0.60497017, -0.66630228],
-            [1.39272351, -0.51631728],
-            [-1.55581933, 1.09609604],
-            [1.55157493, -1.6981518],
-        ]
+@pytest.fixture(scope="module")
+def data():
+    return make_classification(
+        n_samples=200,
+        n_features=2,
+        n_informative=2,
+        n_redundant=0,
+        n_repeated=0,
+        n_clusters_per_class=1,
+        n_classes=3,
+        weights=[0.1, 0.3, 0.6],
+        random_state=0,
     )
-    y_gt = np.array([1, 1, 1, 2, 2, 0, 0, 2, 1, 2])
-    assert_array_equal(X_resampled, X_gt)
-    assert_array_equal(y_resampled, y_gt)
 
 
-def test_ncr_fit_resample_mode():
-    ncr = NeighbourhoodCleaningRule(kind_sel="mode")
-    X_resampled, y_resampled = ncr.fit_resample(X, Y)
-
-    X_gt = np.array(
-        [
-            [0.34096173, 0.50947647],
-            [-0.91735824, 0.93110278],
-            [-0.20413357, 0.64628718],
-            [0.35967591, 2.61186964],
-            [0.90701028, -0.57636928],
-            [-1.20809175, -1.49917302],
-            [-0.60497017, -0.66630228],
-            [1.39272351, -0.51631728],
-            [-1.55581933, 1.09609604],
-            [1.55157493, -1.6981518],
-        ]
+def test_ncr_threshold_cleaning(data):
+    """Test the effect of the `threshold_cleaning` parameter."""
+    X, y = data
+    # with a large `threshold_cleaning`, the algorithm is equivalent to ENN
+    enn = EditedNearestNeighbours()
+    ncr = NeighbourhoodCleaningRule(
+        edited_nearest_neighbours=enn, n_neighbors=10, threshold_cleaning=10
     )
-    y_gt = np.array([1, 1, 1, 2, 2, 0, 0, 2, 1, 2])
-    assert_array_equal(X_resampled, X_gt)
-    assert_array_equal(y_resampled, y_gt)
+
+    enn.fit_resample(X, y)
+    ncr.fit_resample(X, y)
+
+    assert_array_equal(np.sort(enn.sample_indices_), np.sort(ncr.sample_indices_))
+    assert ncr.classes_to_clean_ == []
+
+    # set a threshold that we should consider only the class #2
+    counter = Counter(y)
+    threshold = counter[1] / counter[0]
+    ncr.set_params(threshold_cleaning=threshold)
+    ncr.fit_resample(X, y)
+
+    assert set(ncr.classes_to_clean_) == {2}
+
+    # making the threshold slightly smaller to take into account class #1
+    ncr.set_params(threshold_cleaning=threshold - np.finfo(np.float32).eps)
+    ncr.fit_resample(X, y)
+
+    assert set(ncr.classes_to_clean_) == {1, 2}
+
+
+def test_ncr_n_neighbors(data):
+    """Check the effect of the NN on the cleaning of the second phase."""
+    X, y = data
+
+    enn = EditedNearestNeighbours()
+    ncr = NeighbourhoodCleaningRule(edited_nearest_neighbours=enn, n_neighbors=3)
+
+    ncr.fit_resample(X, y)
+    sample_indices_3_nn = ncr.sample_indices_
+
+    ncr.set_params(n_neighbors=10).fit_resample(X, y)
+    sample_indices_10_nn = ncr.sample_indices_
+
+    # we should have a more aggressive cleaning with n_neighbors is larger
+    assert len(sample_indices_3_nn) > len(sample_indices_10_nn)
+
+
+# TODO: remove in 0.14
+@pytest.mark.parametrize("kind_sel", ["all", "mode"])
+def test_ncr_deprecate_kind_sel(data, kind_sel):
+    X, y = data
+
+    with pytest.warns(FutureWarning, match="`kind_sel` is deprecated"):
+        NeighbourhoodCleaningRule(kind_sel=kind_sel).fit_resample(X, y)


### PR DESCRIPTION
closes #764 

Solve several issues in `NeighbourhoodCleaningRule`:

- apply the `threshold_cleaning` on the minority classes and not the full dataset
- deprecate `kind_sel` since it does not make in regards to the proposed literature. We need to remove samples that are linked with the misclassification of samples using the NN rule for the minority class.
- Make the code for this selection clearer.