### PR TITLE
DOC fix the strategy used for multiclass in IHT

### DIFF
--- a/imblearn/under_sampling/_prototype_selection/_instance_hardness_threshold.py
+++ b/imblearn/under_sampling/_prototype_selection/_instance_hardness_threshold.py
@@ -83,8 +83,8 @@ class InstanceHardnessThreshold(BaseUnderSampler):
     -----
     The method is based on [1]_.
 
-    Supports multi-class resampling. A one-vs.-rest scheme is used when
-    sampling a class as proposed in [1]_.
+    Supports multi-class resampling. We will go through each individual class to select
+    the samples with the highest probability to be correctly classified.
 
     References
     ----------


### PR DESCRIPTION
closes #848 

Update the docstring regarding the multiclass approach used in IHT. We don't use one vs. rest. Instead, we filter samples based on their classes and the assigned probabilities of a learner.