### PR TITLE
DOC udpate the datasets used in CondensedNearestNeighbour docstring

### DIFF
--- a/doc/developers_utils.rst
+++ b/doc/developers_utils.rst
@@ -31,7 +31,7 @@ should be used when applicable.
 - :func:`check_neighbors_object`: Check the objects is consistent to be a NN.
 - :func:`check_target_type`: Check the target types to be conform to the current
   samplers.
-- :func:`check_sampling_strategy`: Checks that sampling target is onsistent with
+- :func:`check_sampling_strategy`: Checks that sampling target is consistent with
   the type and return a dictionary containing each targeted class with its
   corresponding number of pixel.
 

--- a/imblearn/under_sampling/_prototype_selection/_condensed_nearest_neighbour.py
+++ b/imblearn/under_sampling/_prototype_selection/_condensed_nearest_neighbour.py
@@ -110,19 +110,18 @@ class CondensedNearestNeighbour(BaseCleaningSampler):
     Examples
     --------
     >>> from collections import Counter  # doctest: +SKIP
-    >>> from sklearn.datasets import make_classification  # doctest: +SKIP
+    >>> from sklearn.datasets import fetch_openml  # doctest: +SKIP
+    >>> from sklearn.preprocessing import scale  # doctest: +SKIP
     >>> from imblearn.under_sampling import \
 CondensedNearestNeighbour  # doctest: +SKIP
-    >>> X, y = make_classification(n_classes=2, class_sep=2, \
-weights=[0.1, 0.9], n_informative=3, n_redundant=1, flip_y=0, \
-n_features=20, n_clusters_per_class=1, n_samples=1000, \
-random_state=10)  # doctest: +SKIP
+    >>> X, y = fetch_openml('diabetes', version=1, return_X_y=True)  # doctest: +SKIP
+    >>> X = scale(X)  # doctest: +SKIP
     >>> print('Original dataset shape %s' % Counter(y))  # doctest: +SKIP
-    Original dataset shape Counter({{1: 900, 0: 100}})  # doctest: +SKIP
+    Original dataset shape Counter({{1: 500, 0: 268}})  # doctest: +SKIP
     >>> cnn = CondensedNearestNeighbour(random_state=42)  # doctest: +SKIP
     >>> X_res, y_res = cnn.fit_resample(X, y)  #doctest: +SKIP
     >>> print('Resampled dataset shape %s' % Counter(y_res))  # doctest: +SKIP
-    Resampled dataset shape Counter({{0: 100, 1: 44}})  # doctest: +SKIP
+    Resampled dataset shape Counter({{0: 268, 1: 181}})  # doctest: +SKIP
     """
 
     _parameter_constraints: dict = {

--- a/imblearn/under_sampling/_prototype_selection/_condensed_nearest_neighbour.py
+++ b/imblearn/under_sampling/_prototype_selection/_condensed_nearest_neighbour.py
@@ -117,11 +117,13 @@ CondensedNearestNeighbour  # doctest: +SKIP
     >>> X, y = fetch_openml('diabetes', version=1, return_X_y=True)  # doctest: +SKIP
     >>> X = scale(X)  # doctest: +SKIP
     >>> print('Original dataset shape %s' % Counter(y))  # doctest: +SKIP
-    Original dataset shape Counter({{1: 500, 0: 268}})  # doctest: +SKIP
+    Original dataset shape Counter({{'tested_negative': 500, \
+        'tested_positive': 268}})  # doctest: +SKIP
     >>> cnn = CondensedNearestNeighbour(random_state=42)  # doctest: +SKIP
     >>> X_res, y_res = cnn.fit_resample(X, y)  #doctest: +SKIP
     >>> print('Resampled dataset shape %s' % Counter(y_res))  # doctest: +SKIP
-    Resampled dataset shape Counter({{0: 268, 1: 181}})  # doctest: +SKIP
+    Resampled dataset shape Counter({{'tested_positive': 268, \
+        'tested_negative': 181}})  # doctest: +SKIP
     """
 
     _parameter_constraints: dict = {

--- a/imblearn/under_sampling/_prototype_selection/_condensed_nearest_neighbour.py
+++ b/imblearn/under_sampling/_prototype_selection/_condensed_nearest_neighbour.py
@@ -110,17 +110,19 @@ class CondensedNearestNeighbour(BaseCleaningSampler):
     Examples
     --------
     >>> from collections import Counter  # doctest: +SKIP
-    >>> from sklearn.datasets import fetch_mldata  # doctest: +SKIP
+    >>> from sklearn.datasets import make_classification  # doctest: +SKIP
     >>> from imblearn.under_sampling import \
 CondensedNearestNeighbour  # doctest: +SKIP
-    >>> pima = fetch_mldata('diabetes_scale')  # doctest: +SKIP
-    >>> X, y = pima['data'], pima['target']  # doctest: +SKIP
+    >>> X, y = make_classification(n_classes=2, class_sep=2, \
+weights=[0.1, 0.9], n_informative=3, n_redundant=1, flip_y=0, \
+n_features=20, n_clusters_per_class=1, n_samples=1000, \
+random_state=10)  # doctest: +SKIP
     >>> print('Original dataset shape %s' % Counter(y))  # doctest: +SKIP
-    Original dataset shape Counter({{1: 500, -1: 268}})  # doctest: +SKIP
+    Original dataset shape Counter({{1: 900, 0: 100}})  # doctest: +SKIP
     >>> cnn = CondensedNearestNeighbour(random_state=42)  # doctest: +SKIP
     >>> X_res, y_res = cnn.fit_resample(X, y)  #doctest: +SKIP
     >>> print('Resampled dataset shape %s' % Counter(y_res))  # doctest: +SKIP
-    Resampled dataset shape Counter({{-1: 268, 1: 227}})  # doctest: +SKIP
+    Resampled dataset shape Counter({{0: 100, 1: 44}})  # doctest: +SKIP
     """
 
     _parameter_constraints: dict = {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
Fixes #1040.
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
This is a suggestion to use the same dataset generator `sklearn.datasets.make_classification` as is used in the doc of e.g. `ClusterCentroids` instead of the dead `sklearn.datasets.fetch_mldata`.

#### Any other comments?
This is a suggestion, if you are interested in a low-cost fix. There may be more interesting datasets which could be used, or ones you find more illustrative.

btw pycodestyle gave me a few warnings of E501 about lines being longer than 79 characters, but I think you have a max line length of 88 in your checks which I think is also fine. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
