### PR TITLE
FIX InstanceHardnessThreshold accepts classifier included in a Pipeline

### DIFF
--- a/doc/whats_new/v0.12.rst
+++ b/doc/whats_new/v0.12.rst
@@ -1,5 +1,20 @@
 .. _changes_0_12:
 
+Version 0.12.1
+==============
+
+**In progress**
+
+Changelog
+---------
+
+Bug fixes
+.........
+
+- Fix a bug in :class:`~imblearn.under_sampling.InstanceHardnessThreshold` where
+  `estimator` could not be a :class:`~sklearn.pipeline.Pipeline` object.
+  :pr:`1049` by :user:`Gonenc Mogol <gmogol>`.
+
 Version 0.12.0
 ==============
 

--- a/imblearn/under_sampling/_prototype_selection/_instance_hardness_threshold.py
+++ b/imblearn/under_sampling/_prototype_selection/_instance_hardness_threshold.py
@@ -20,6 +20,7 @@ from ...utils import Substitution
 from ...utils._docstring import _n_jobs_docstring, _random_state_docstring
 from ...utils._param_validation import HasMethods
 from ..base import BaseUnderSampler
+from sklearn.pipeline import Pipeline
 
 
 @Substitution(
@@ -140,7 +141,9 @@ class InstanceHardnessThreshold(BaseUnderSampler):
 
         if (
             self.estimator is not None
-            and isinstance(self.estimator, ClassifierMixin)
+            and (isinstance(self.estimator, ClassifierMixin) or
+                 isinstance(self.estimator, ClassifierMixin) )
+                 
             and hasattr(self.estimator, "predict_proba")
         ):
             self.estimator_ = clone(self.estimator)

--- a/imblearn/under_sampling/_prototype_selection/_instance_hardness_threshold.py
+++ b/imblearn/under_sampling/_prototype_selection/_instance_hardness_threshold.py
@@ -10,7 +10,7 @@ import numbers
 from collections import Counter
 
 import numpy as np
-from sklearn.base import ClassifierMixin, clone
+from sklearn.base import clone, is_classifier
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.ensemble._base import _set_random_states
 from sklearn.model_selection import StratifiedKFold, cross_val_predict
@@ -20,7 +20,6 @@ from ...utils import Substitution
 from ...utils._docstring import _n_jobs_docstring, _random_state_docstring
 from ...utils._param_validation import HasMethods
 from ..base import BaseUnderSampler
-from sklearn.pipeline import Pipeline
 
 
 @Substitution(
@@ -141,9 +140,7 @@ class InstanceHardnessThreshold(BaseUnderSampler):
 
         if (
             self.estimator is not None
-            and (isinstance(self.estimator, ClassifierMixin) or
-                 isinstance(self.estimator, Pipeline) )
-                 
+            and is_classifier(self.estimator)
             and hasattr(self.estimator, "predict_proba")
         ):
             self.estimator_ = clone(self.estimator)

--- a/imblearn/under_sampling/_prototype_selection/_instance_hardness_threshold.py
+++ b/imblearn/under_sampling/_prototype_selection/_instance_hardness_threshold.py
@@ -142,7 +142,7 @@ class InstanceHardnessThreshold(BaseUnderSampler):
         if (
             self.estimator is not None
             and (isinstance(self.estimator, ClassifierMixin) or
-                 isinstance(self.estimator, ClassifierMixin) )
+                 isinstance(self.estimator, Pipeline) )
                  
             and hasattr(self.estimator, "predict_proba")
         ):

--- a/imblearn/under_sampling/_prototype_selection/tests/test_instance_hardness_threshold.py
+++ b/imblearn/under_sampling/_prototype_selection/tests/test_instance_hardness_threshold.py
@@ -6,6 +6,7 @@
 import numpy as np
 from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
 from sklearn.naive_bayes import GaussianNB as NB
+from sklearn.pipeline import make_pipeline
 from sklearn.utils._testing import assert_array_equal
 
 from imblearn.under_sampling import InstanceHardnessThreshold
@@ -91,5 +92,21 @@ def test_iht_fit_resample_default_estimator():
     iht = InstanceHardnessThreshold(estimator=None, random_state=RND_SEED)
     X_resampled, y_resampled = iht.fit_resample(X, Y)
     assert isinstance(iht.estimator_, RandomForestClassifier)
+    assert X_resampled.shape == (12, 2)
+    assert y_resampled.shape == (12,)
+
+
+def test_iht_estimator_pipeline():
+    """Check that we can pass a pipeline containing a classifier.
+
+    Checking if we have a classifier should not be based on inheriting from
+    `ClassifierMixin`.
+
+    Non-regression test for:
+    https://github.com/scikit-learn-contrib/imbalanced-learn/pull/1049
+    """
+    model = make_pipeline(GradientBoostingClassifier(random_state=RND_SEED))
+    iht = InstanceHardnessThreshold(estimator=model, random_state=RND_SEED)
+    X_resampled, y_resampled = iht.fit_resample(X, Y)
     assert X_resampled.shape == (12, 2)
     assert y_resampled.shape == (12,)


### PR DESCRIPTION
Added the option to add a pipeline as an estimator for instance hardness threshold. Currently using a pipeline as an estimator fails because of the instance check. I think it's useful to be able to use pipelines as estimators and have thus added it.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
