### PR TITLE
MAINT drop disutils and use scikit-learn fixes instead

### DIFF
--- a/doc/whats_new/v0.12.rst
+++ b/doc/whats_new/v0.12.rst
@@ -15,6 +15,12 @@ Bug fixes
   `estimator` could not be a :class:`~sklearn.pipeline.Pipeline` object.
   :pr:`1049` by :user:`Gonenc Mogol <gmogol>`.
 
+Compatibility
+.............
+
+- Do not use `distutils` in tests due to deprecation.
+  :pr:`1065` by :user:`Michael R. Crusoe <mr-c>`
+
 Version 0.12.0
 ==============
 

--- a/imblearn/_min_dependencies.py
+++ b/imblearn/_min_dependencies.py
@@ -37,7 +37,6 @@ dependent_packages = {
     "numpydoc": ("1.5.0", "docs"),
     "sphinxcontrib-bibtex": ("2.4.1", "docs"),
     "pydata-sphinx-theme": ("0.13.3", "docs"),
-    "packaging":("14.1", "tests"),
 }
 
 

--- a/imblearn/_min_dependencies.py
+++ b/imblearn/_min_dependencies.py
@@ -37,6 +37,7 @@ dependent_packages = {
     "numpydoc": ("1.5.0", "docs"),
     "sphinxcontrib-bibtex": ("2.4.1", "docs"),
     "pydata-sphinx-theme": ("0.13.3", "docs"),
+    "packaging":("14.1", "tests"),
 }
 
 

--- a/imblearn/tensorflow/tests/test_generator.py
+++ b/imblearn/tensorflow/tests/test_generator.py
@@ -1,9 +1,8 @@
-from packaging.version import parse
-
 import numpy as np
 import pytest
 from scipy import sparse
 from sklearn.datasets import load_iris
+from sklearn.utils.fixes import parse_version
 
 from imblearn.datasets import make_imbalance
 from imblearn.over_sampling import RandomOverSampler
@@ -147,7 +146,7 @@ def check_balanced_batch_generator_tf_2_X_X_compat_1_X_X(dataset, sampler):
 
 @pytest.mark.parametrize("sampler", [None, NearMiss(), RandomOverSampler()])
 def test_balanced_batch_generator(data, sampler):
-    if parse(tf.__version__) < "2":
+    if parse_version(tf.__version__) < "2":
         check_balanced_batch_generator_tf_1_X_X(data, sampler)
     else:
         check_balanced_batch_generator_tf_2_X_X_compat_1_X_X(data, sampler)

--- a/imblearn/tensorflow/tests/test_generator.py
+++ b/imblearn/tensorflow/tests/test_generator.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import parse
 
 import numpy as np
 import pytest
@@ -147,7 +147,7 @@ def check_balanced_batch_generator_tf_2_X_X_compat_1_X_X(dataset, sampler):
 
 @pytest.mark.parametrize("sampler", [None, NearMiss(), RandomOverSampler()])
 def test_balanced_batch_generator(data, sampler):
-    if LooseVersion(tf.__version__) < "2":
+    if parse(tf.__version__) < "2":
         check_balanced_batch_generator_tf_1_X_X(data, sampler)
     else:
         check_balanced_batch_generator_tf_2_X_X_compat_1_X_X(data, sampler)

--- a/imblearn/tensorflow/tests/test_generator.py
+++ b/imblearn/tensorflow/tests/test_generator.py
@@ -146,7 +146,7 @@ def check_balanced_batch_generator_tf_2_X_X_compat_1_X_X(dataset, sampler):
 
 @pytest.mark.parametrize("sampler", [None, NearMiss(), RandomOverSampler()])
 def test_balanced_batch_generator(data, sampler):
-    if parse_version(tf.__version__) < "2":
+    if parse_version(tf.__version__) < parse_version("2.0.0"):
         check_balanced_batch_generator_tf_1_X_X(data, sampler)
     else:
         check_balanced_batch_generator_tf_2_X_X_compat_1_X_X(data, sampler)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Distutils is deprecated. Use the equivalent function from the [`packaging` package](https://pypi.org/project/packaging/) instead. Pytest and others already depend on that, but I added it to the test dependencies to be sure.

#### Any other comments?

This patch was [needed in the Debian package of `imbalanced-learn`.](https://salsa.debian.org/med-team/imbalanced-learn/-/blob/master/debian/patches/python-3.12.patch?ref_type=heads)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
