### PR TITLE
MAINT update the python version supported

### DIFF
--- a/doc/whats_new/v0.12.rst
+++ b/doc/whats_new/v0.12.rst
@@ -22,10 +22,10 @@ Compatibility
   :pr:`1065` by :user:`Michael R. Crusoe <mr-c>`.
 
 - Fix the scikit-learn import in tests to be compatible with version 1.4.1.post1.
-  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`1073` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 - Fix test to be compatible with Python 3.13.
-  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`1073` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 Version 0.12.0
 ==============

--- a/doc/whats_new/v0.12.rst
+++ b/doc/whats_new/v0.12.rst
@@ -19,7 +19,13 @@ Compatibility
 .............
 
 - Do not use `distutils` in tests due to deprecation.
-  :pr:`1065` by :user:`Michael R. Crusoe <mr-c>`
+  :pr:`1065` by :user:`Michael R. Crusoe <mr-c>`.
+
+- Fix the scikit-learn import in tests to be compatible with version 1.4.1.post1.
+  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+
+- Fix test to be compatible with Python 3.13.
+  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 Version 0.12.0
 ==============

--- a/imblearn/utils/tests/test_docstring.py
+++ b/imblearn/utils/tests/test_docstring.py
@@ -3,10 +3,22 @@
 # Authors: Guillaume Lemaitre <g.lemaitre58@gmail.com>
 # License: MIT
 
+import sys
+import textwrap
+
 import pytest
 
 from imblearn.utils import Substitution
 from imblearn.utils._docstring import _n_jobs_docstring, _random_state_docstring
+
+
+def _dedent_docstring(docstring):
+    """Compatibility with Python 3.13+.
+
+    xref: https://github.com/python/cpython/issues/81283
+    """
+    return "\n".join([textwrap.dedent(line) for line in docstring.split("\n")])
+
 
 func_docstring = """A function.
 
@@ -53,6 +65,11 @@ class cls:
     def __init__(self, param_1, param_2):
         self.param_1 = param_1
         self.param_2 = param_2
+
+
+if sys.version_info.minor == "13":
+    func_docstring = _dedent_docstring(func_docstring)
+    cls_docstring = _dedent_docstring(cls_docstring)
 
 
 @pytest.mark.parametrize(

--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,10 @@ CLASSIFIERS = [
     "Operating System :: POSIX",
     "Operating System :: Unix",
     "Operating System :: MacOS",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 PYTHON_REQUIRES = ">=3.8"
 INSTALL_REQUIRES = (min_deps.tag_to_packages["install"],)


### PR DESCRIPTION
closes #1071

Update the supported python version and anticipate the release of Python 3.13.