### PR TITLE
FIX change the way we check for a specific Python version in the test suite

### DIFF
--- a/doc/whats_new/v0.12.rst
+++ b/doc/whats_new/v0.12.rst
@@ -12,7 +12,7 @@ Bug fixes
 .........
 
 - Fix the way we check for a specific Python version in the test suite.
-  :pr:`zxxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`1075` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 Version 0.12.1
 ==============

--- a/doc/whats_new/v0.12.rst
+++ b/doc/whats_new/v0.12.rst
@@ -1,9 +1,23 @@
 .. _changes_0_12:
 
+Version 0.12.2
+==============
+
+**March 31, 2024**
+
+Changelog
+---------
+
+Bug fixes
+.........
+
+- Fix the way we check for a specific Python version in the test suite.
+  :pr:`zxxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Version 0.12.1
 ==============
 
-**In progress**
+**March 31, 2024**
 
 Changelog
 ---------

--- a/imblearn/utils/tests/test_docstring.py
+++ b/imblearn/utils/tests/test_docstring.py
@@ -67,7 +67,7 @@ class cls:
         self.param_2 = param_2
 
 
-if sys.version_info.minor == "13":
+if sys.version_info >= (3, 13):
     func_docstring = _dedent_docstring(func_docstring)
     cls_docstring = _dedent_docstring(cls_docstring)
 


### PR DESCRIPTION
Made a mistake in the original fix.