### PR TITLE
MAINT compatibility scikit-learn 1.5.2 and Numpy 2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -255,7 +255,7 @@ jobs:
 - template: build_tools/azure/posix.yml
   parameters:
     name: macOS
-    vmImage: macOS-11
+    vmImage: macOS-12
     dependsOn: [linting, git_commit]
     condition: |
       and(

--- a/conftest.py
+++ b/conftest.py
@@ -7,7 +7,14 @@
 
 import os
 
+import numpy as np
 import pytest
+from sklearn.utils.fixes import parse_version
+
+# use legacy numpy print options to avoid failures due to NumPy 2.+ scalar
+# representation
+if parse_version(np.__version__) > parse_version("2.0.0"):
+    np.set_printoptions(legacy="1.25")
 
 
 def pytest_runtest_setup(item):

--- a/imblearn/metrics/pairwise.py
+++ b/imblearn/metrics/pairwise.py
@@ -161,7 +161,7 @@ class ValueDifferenceMetric(_ParamsValidationMixin, BaseEstimator):
                     f"elements in n_categories and {self.n_features_in_} in "
                     f"X."
                 )
-            self.n_categories_ = np.array(self.n_categories, copy=False)
+            self.n_categories_ = np.asarray(self.n_categories)
         classes = unique_labels(y)
 
         # list of length n_features of ndarray (n_categories, n_classes)

--- a/imblearn/utils/estimator_checks.py
+++ b/imblearn/utils/estimator_checks.py
@@ -309,7 +309,7 @@ def check_samplers_sparse(name, sampler_orig):
     sampler = clone(sampler)
     X_res, y_res = sampler.fit_resample(X, y)
     assert sparse.issparse(X_res_sparse)
-    assert_allclose(X_res_sparse.A, X_res, rtol=1e-5)
+    assert_allclose(X_res_sparse.toarray(), X_res, rtol=1e-5)
     assert_allclose(y_res_sparse, y_res)
 
 


### PR DESCRIPTION
This PR makes sure that we are compatible with scikit-learn 1.5.2 and NumPy >2