### PR TITLE
[MRG] ENH add macro-averaged mean squared error

### DIFF
--- a/doc/metrics.rst
+++ b/doc/metrics.rst
@@ -60,6 +60,14 @@ The :func:`macro_averaged_mean_absolute_error` :cite:`esuli2009ordinal` is used
 for imbalanced ordinal classification. The mean absolute error is computed for
 each class and averaged over classes, giving an equal weight to each class.
 
+.. _macro_averaged_mean_squared_error:
+
+Macro-Averaged Mean Squared Error (MA-MSE)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Like MA-MAE, but it penalizes errors that are further from the ground truth more
+harshly, in the same fashion as MSE for MAE.
+
 .. _classification_report:
 
 Summary of important metrics

--- a/doc/references/metrics.rst
+++ b/doc/references/metrics.rst
@@ -23,6 +23,7 @@ See the :ref:`metrics` section of the user guide for further details.
    specificity_score
    geometric_mean_score
    macro_averaged_mean_absolute_error
+   macro_averaged_mean_squared_error
    make_index_balanced_accuracy
 
 Pairwise metrics

--- a/imblearn/metrics/__init__.py
+++ b/imblearn/metrics/__init__.py
@@ -7,6 +7,7 @@ from ._classification import (
     classification_report_imbalanced,
     geometric_mean_score,
     macro_averaged_mean_absolute_error,
+    macro_averaged_mean_squared_error,
     make_index_balanced_accuracy,
     sensitivity_score,
     sensitivity_specificity_support,
@@ -21,4 +22,5 @@ __all__ = [
     "make_index_balanced_accuracy",
     "classification_report_imbalanced",
     "macro_averaged_mean_absolute_error",
+    "macro_averaged_mean_squared_error",
 ]

--- a/imblearn/metrics/tests/test_classification.py
+++ b/imblearn/metrics/tests/test_classification.py
@@ -30,6 +30,7 @@ from imblearn.metrics import (
     classification_report_imbalanced,
     geometric_mean_score,
     macro_averaged_mean_absolute_error,
+    macro_averaged_mean_squared_error,
     make_index_balanced_accuracy,
     sensitivity_score,
     sensitivity_specificity_support,
@@ -544,6 +545,36 @@ def test_macro_averaged_mean_absolute_error_sample_weight():
 
     sample_weight = [1, 1, 1, 1, 1, 1]
     ma_mae_unit_weights = macro_averaged_mean_absolute_error(
+        y_true,
+        y_pred,
+        sample_weight=sample_weight,
+    )
+
+    assert ma_mae_unit_weights == pytest.approx(ma_mae_no_weights)
+
+
+@pytest.mark.parametrize(
+    "y_true, y_pred, expected_ma_mae",
+    [
+        ([1, 1, 1, 2, 2, 2], [1, 2, 1, 2, 1, 2], 0.333),
+        ([1, 1, 1, 1, 1, 2], [1, 2, 1, 2, 1, 2], 0.2),
+        ([1, 1, 1, 2, 2, 2, 3, 3, 3], [1, 3, 1, 2, 1, 1, 2, 3, 3], 0.777),
+        ([1, 1, 1, 1, 1, 1, 2, 3, 3], [1, 3, 1, 2, 1, 1, 2, 3, 3], 0.277),
+    ],
+)
+def test_macro_averaged_mean_squared_error(y_true, y_pred, expected_ma_mae):
+    ma_mae = macro_averaged_mean_squared_error(y_true, y_pred)
+    assert ma_mae == pytest.approx(expected_ma_mae, rel=R_TOL)
+
+
+def test_macro_averaged_mean_squared_error_sample_weight():
+    y_true = [1, 1, 1, 2, 2, 2]
+    y_pred = [1, 2, 1, 2, 1, 2]
+
+    ma_mae_no_weights = macro_averaged_mean_squared_error(y_true, y_pred)
+
+    sample_weight = [1, 1, 1, 1, 1, 1]
+    ma_mae_unit_weights = macro_averaged_mean_squared_error(
         y_true,
         y_pred,
         sample_weight=sample_weight,

--- a/imblearn/tests/test_public_functions.py
+++ b/imblearn/tests/test_public_functions.py
@@ -17,6 +17,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "imblearn.metrics.classification_report_imbalanced",
     "imblearn.metrics.geometric_mean_score",
     "imblearn.metrics.macro_averaged_mean_absolute_error",
+    "imblearn.metrics.macro_averaged_mean_squared_error",
     "imblearn.metrics.make_index_balanced_accuracy",
     "imblearn.metrics.sensitivity_specificity_support",
     "imblearn.metrics.sensitivity_score",


### PR DESCRIPTION
#### Reference Issue

Closes #846


#### What does this implement/fix? Explain your changes.

New metric for ordinal classification: `macro_averaged_mean_squared_error`, following the same logic as the previously introduced `macro_averaged_mean_absolute_error`.

Changes:
- implemented `macro_averaged_mean_squared_error`
- added new metric entry, reference and link in the documentation
- exported function in `__init__.py`
- added minimal test case & registered test public function


#### Any other comments?

A comment in the issue suggested adding a `squared=True` parameter.

As of scikit-learn 1.4 (see <https://github.com/scikit-learn/scikit-learn/pull/26734>), this is now outdated: the new function is standalone.

<br>
Let me know if further changes are needed.

