### PR TITLE
[MRG]Fix compatibility with scikit-learn 1.8+

### DIFF
--- a/doc/ensemble.rst
+++ b/doc/ensemble.rst
@@ -97,8 +97,7 @@ Several methods taking advantage of boosting have been designed.
 a boosting iteration :cite:`seiffert2009rusboost`::
 
   >>> from imblearn.ensemble import RUSBoostClassifier
-  >>> rusboost = RUSBoostClassifier(n_estimators=200, algorithm='SAMME.R',
-  ...                               random_state=0)
+  >>> rusboost = RUSBoostClassifier(n_estimators=200, random_state=0)
   >>> rusboost.fit(X_train, y_train)
   RUSBoostClassifier(...)
   >>> y_pred = rusboost.predict(X_test)

--- a/examples/ensemble/plot_comparison_ensemble_classifier.py
+++ b/examples/ensemble/plot_comparison_ensemble_classifier.py
@@ -194,10 +194,16 @@ fig.tight_layout()
 
 # %%
 from sklearn.ensemble import AdaBoostClassifier
+from sklearn.utils.fixes import parse_version
 
 from imblearn.ensemble import EasyEnsembleClassifier, RUSBoostClassifier
+from imblearn.utils._sklearn_compat import sklearn_version
 
-estimator = AdaBoostClassifier(n_estimators=10, algorithm="SAMME")
+if sklearn_version < parse_version("1.6"):
+    estimator = AdaBoostClassifier(n_estimators=10, algorithm="SAMME")
+else:
+    estimator = AdaBoostClassifier(n_estimators=10)
+
 eec = EasyEnsembleClassifier(n_estimators=10, estimator=estimator)
 eec.fit(X_train, y_train)
 y_pred_eec = eec.predict(X_test)

--- a/imblearn/ensemble/_easy_ensemble.py
+++ b/imblearn/ensemble/_easy_ensemble.py
@@ -226,12 +226,14 @@ class EasyEnsembleClassifier(BaggingClassifier):
             self._sampling_strategy = self.sampling_strategy
         return y_encoded
 
-    def _validate_estimator(self, default=AdaBoostClassifier(algorithm="SAMME")):
+    def _validate_estimator(self, default=None):
         """Check the estimator and the n_estimator attribute, set the
         `estimator_` attribute."""
         if self.estimator is not None:
             estimator = clone(self.estimator)
         else:
+            if default is None:
+                default = self._get_estimator()
             estimator = clone(default)
 
         sampler = RandomUnderSampler(
@@ -279,7 +281,7 @@ class EasyEnsembleClassifier(BaggingClassifier):
 
     def _get_estimator(self):
         if self.estimator is None:
-            if parse_version("1.4") <= sklearn_version < parse_version("1.6"):
+            if sklearn_version < parse_version("1.6"):
                 return AdaBoostClassifier(algorithm="SAMME")
             else:
                 return AdaBoostClassifier()

--- a/imblearn/metrics/_classification.py
+++ b/imblearn/metrics/_classification.py
@@ -25,10 +25,11 @@ from sklearn.metrics import mean_absolute_error, precision_recall_fscore_support
 from sklearn.metrics._classification import _check_targets, _prf_divide
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils._param_validation import Interval, StrOptions
+from sklearn.utils.fixes import parse_version
 from sklearn.utils.multiclass import unique_labels
 from sklearn.utils.validation import check_consistent_length, column_or_1d
 
-from ..utils._sklearn_compat import validate_params
+from ..utils._sklearn_compat import sklearn_version, validate_params
 
 
 @validate_params(
@@ -166,7 +167,12 @@ def sensitivity_specificity_support(
     if average not in average_options and average != "binary":
         raise ValueError("average has to be one of " + str(average_options))
 
-    y_type, y_true, y_pred = _check_targets(y_true, y_pred)
+    if sklearn_version >= parse_version("1.8"):
+        y_type, y_true, y_pred, sample_weight = _check_targets(
+            y_true, y_pred, sample_weight
+        )
+    else:
+        y_type, y_true, y_pred = _check_targets(y_true, y_pred)
     present_labels = unique_labels(y_true, y_pred)
 
     if average == "binary":
@@ -1119,11 +1125,18 @@ def macro_averaged_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
     >>> macro_averaged_mean_absolute_error(y_true_imbalanced, y_pred)
     0.16...
     """
-    _, y_true, y_pred = _check_targets(y_true, y_pred)
-    if sample_weight is not None:
-        sample_weight = column_or_1d(sample_weight)
+    if sklearn_version >= parse_version("1.8"):
+        _, y_true, y_pred, sample_weight = _check_targets(
+            y_true, y_pred, sample_weight
+        )
+        if sample_weight is None:
+            sample_weight = np.ones(y_true.shape)
     else:
-        sample_weight = np.ones(y_true.shape)
+        _, y_true, y_pred = _check_targets(y_true, y_pred)
+        if sample_weight is not None:
+            sample_weight = column_or_1d(sample_weight)
+        else:
+            sample_weight = np.ones(y_true.shape)
     check_consistent_length(y_true, y_pred, sample_weight)
     labels = unique_labels(y_true, y_pred)
     mae = []


### PR DESCRIPTION
scikit-learn 1.8.0+ removed the algorithm parameter from AdaBoostClassifier and changed the function signature of _check_targets().

https://github.com/scikit-learn/scikit-learn/pull/32262
https://github.com/scikit-learn/scikit-learn/pull/31701

The changes maintain compatibility with previous version of scikit-learn

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->

#### What does this implement/fix? Explain your changes.

This fixes compatibility with scikit-learn 1.8.0+

#### Any other comments?

Tested on Fedora with scikit-learn 1.8.0rc1 as well as 1.7.2 and Python 3.14. All tests passed.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
