### PR TITLE
[DOC] Add warning about over-sampling limitations

### DIFF
--- a/doc/over_sampling.rst
+++ b/doc/over_sampling.rst
@@ -1,4 +1,4 @@
-.. _over-sampling:
+oo.. _over-sampling:
 
 =============
 Over-sampling
@@ -11,6 +11,17 @@ A practical guide
 
 You can refer to
 :ref:`sphx_glr_auto_examples_over-sampling_plot_comparison_over_sampling.py`.
+
+.. warning::
+
+   Over-sampling methods (including random over-sampling, SMOTE, and ADASYN) do
+   not guarantee improved predictive performance. In particular, they may not
+   improve ranking metrics such as ROC-AUC and can degrade probability
+   calibration. We recommend validating the impact using the metric(s) that
+   matter for your use case, and considering alternatives such as using
+   ``class_weight`` or ``sample_weight`` in the estimator, tuning the decision
+   threshold, or collecting more minority class data when possible.
+
 
 .. _random_over_sampler:
 


### PR DESCRIPTION
#### Reference Issue
Fixes #1101

#### What does this implement/fix? Explain your changes.
This PR adds a visible warning at the top of the over-sampling user guide to set expectations about over-sampling methods (e.g., random over-sampling, SMOTE, ADASYN). The warning notes that these methods may not improve ranking metrics (e.g., ROC-AUC) and can degrade probability calibration, and points users to common alternatives such as `class_weight`, `sample_weight`, decision threshold tuning, or collecting more minority data.

#### Any other comments?
This change is documentation only.
