### PR TITLE
DOC: Add visible warning about limitations of oversampling methods

### DIFF
--- a/doc/over_sampling.rst
+++ b/doc/over_sampling.rst
@@ -1,10 +1,24 @@
-.. _over-sampling:
-
 =============
 Over-sampling
 =============
 
 .. currentmodule:: imblearn.over_sampling
+
+.. warning::
+
+   Oversampling methods such as RandomOverSampler, SMOTE and ADASYN
+   artificially modify the class distribution of the training data.
+   While they can improve the recall of the minority class, they do not
+   necessarily improve ranking metrics such as ROC-AUC and can lead to
+   poorly calibrated predicted probabilities.
+
+   In many situations, using ``class_weight`` or ``sample_weight`` in the
+   classifier is a simpler and often more reliable alternative.
+
+   There is ongoing discussion in the research and practitioner community
+   about the usefulness of oversampling methods. These techniques should be
+   used with care and always validated using appropriate metrics, including
+   both discrimination (e.g. ROC-AUC) and probability calibration.
 
 A practical guide
 =================


### PR DESCRIPTION
Fixes #1101

Adds a warning note at the beginning of the over-sampling user guide.

The note highlights some important considerations when using over-sampling
methods such as SMOTE and ADASYN:
- they may have limited impact on ranking-based metrics (e.g. ROC-AUC),
- they can affect probability calibration,
- and they are not always necessary depending on the learning objective.

The warning also points users to alternative approaches such as
`class_weight` and `sample_weight` for handling class imbalance.

This change aims to make new users aware of these trade-offs and help them
choose an appropriate strategy for their specific use case.

