### PR TITLE
Fix ValueError in macro_averaged_mean_absolute_error for missing classes (#1094)

### DIFF
--- a/imblearn/metrics/_classification.py
+++ b/imblearn/metrics/_classification.py
@@ -1131,7 +1131,8 @@ def macro_averaged_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
     mae = []
     for possible_class in labels:
         indices = np.flatnonzero(y_true == possible_class)
-
+        if len(indices) == 0:
+            continue
         mae.append(
             mean_absolute_error(
                 y_true[indices],
@@ -1140,4 +1141,4 @@ def macro_averaged_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
             )
         )
 
-    return np.sum(mae) / len(mae)
+    return np.mean(mae) if mae else 0.0

--- a/imblearn/metrics/tests/test_classification.py
+++ b/imblearn/metrics/tests/test_classification.py
@@ -547,3 +547,11 @@ def test_macro_averaged_mean_absolute_error_sample_weight():
     )
 
     assert ma_mae_unit_weights == pytest.approx(ma_mae_no_weights)
+def test_macro_averaged_mean_absolute_error_missing_class():
+    # Regression test for issue #1094
+    # Class 1 is missing in y_true, but exists in y_pred
+    y_true = [0, 0]
+    y_pred = [0, 1]
+    # Expected: (MAE for class 0 only) / 1 class = 0.5
+    res = macro_averaged_mean_absolute_error(y_true, y_pred)
+    assert res == 0.5


### PR DESCRIPTION
Problem
The function macro_averaged_mean_absolute_error currently crashes with a ValueError (Found array with 0 samples) when a label exists in the predictions (y_pred) or the global labels set, but is entirely absent from the ground truth (y_true). This happens because the function attempts to calculate mean_absolute_error on an empty slice of data.

Solution
This PR introduces a defensive check within the label iteration loop:

Skip Empty Classes: If a class has zero occurrences in y_true, the loop now continues to the next label instead of attempting a calculation on empty arrays.

Robust Return: Changed the final return to use np.mean(mae) with a fallback to 0.0. This prevents a potential ZeroDivisionError if all classes were somehow skipped.

Changes
Modified imblearn/metrics/_classification.py to add the if len(indices) == 0: continue safety guard.

Added a new regression test test_macro_averaged_mean_absolute_error_missing_class in imblearn/metrics/tests/test_classification.py to prevent future regressions.

Verification
Manual Test: Verified that the reproduction script provided in #1094 now returns 0.5 instead of crashing.

Automated Tests: Ran pytest imblearn/metrics/tests/test_classification.py and all 52 tests passed.

Fixes #1094