### PR TITLE
[MRG] FIX geometric_mean_score: macro/weighted average is mean of per-class G-means (#1096)

### DIFF
--- a/doc/whats_new/v0.15.rst
+++ b/doc/whats_new/v0.15.rst
@@ -11,6 +11,14 @@ Changelog
 Bug fixes
 .........
 
+- Fix :func:`~imblearn.metrics.geometric_mean_score` with
+  ``average='macro'`` (and ``'weighted'``): the function now returns the
+  (weighted) mean of the per-class G-means, matching ``np.mean`` of
+  ``geometric_mean_score(..., average=None)`` as users expect. The
+  previous implementation returned ``sqrt(macro_sen * macro_spe)``,
+  which disagreed with the per-class average — most visibly on binary
+  inputs. :pr:`0` by :user:`jbbqqf`.
+
 Enhancements
 ............
 

--- a/doc/whats_new/v0.15.rst
+++ b/doc/whats_new/v0.15.rst
@@ -17,7 +17,7 @@ Bug fixes
   ``geometric_mean_score(..., average=None)`` as users expect. The
   previous implementation returned ``sqrt(macro_sen * macro_spe)``,
   which disagreed with the per-class average — most visibly on binary
-  inputs. :pr:`0` by :user:`jbbqqf`.
+  inputs. :pr:`1173` by :user:`jbbqqf`.
 
 Enhancements
 ............

--- a/imblearn/metrics/_classification.py
+++ b/imblearn/metrics/_classification.py
@@ -662,15 +662,47 @@ def geometric_mean_score(
     >>> geometric_mean_score(y_true, y_pred, correction=0.001)
     0.010...
     >>> geometric_mean_score(y_true, y_pred, average='macro')
-    0.471...
+    0.288...
     >>> geometric_mean_score(y_true, y_pred, average='micro')
     0.471...
     >>> geometric_mean_score(y_true, y_pred, average='weighted')
-    0.471...
+    0.288...
     >>> geometric_mean_score(y_true, y_pred, average=None)
     array([0.866...,  0.       ,  0.       ])
     """
     if average is None or average != "multiclass":
+        # For macro/weighted averaging the previous implementation passed
+        # ``average`` directly to sensitivity_specificity_support, which
+        # returns the macro/weighted average of sensitivity and
+        # specificity, and then took ``sqrt(sen * spe)`` of those scalars.
+        # That is the geometric mean of mean-sensitivity and
+        # mean-specificity, NOT the mean of per-class G-means — and the two
+        # disagree on binary inputs (see #1096). Compute the per-class
+        # G-mean first and aggregate, so that
+        # ``geometric_mean_score(..., average='macro')`` equals
+        # ``np.mean(geometric_mean_score(..., average=None))`` as users
+        # rightly expect.
+        if average in ("macro", "weighted"):
+            sen, spe, sup = sensitivity_specificity_support(
+                y_true,
+                y_pred,
+                labels=labels,
+                pos_label=pos_label,
+                average=None,
+                warn_for=("specificity", "specificity"),
+                sample_weight=sample_weight,
+            )
+            per_class = np.sqrt(sen * spe)
+            if average == "macro":
+                return np.mean(per_class)
+            # weighted: mean weighted by support (true samples per class).
+            # Mirror sklearn's behaviour and return 0 when the total
+            # support is zero rather than producing a NaN from 0/0.
+            total = sup.sum()
+            if total == 0:
+                return 0.0
+            return np.average(per_class, weights=sup)
+
         sen, spe, _ = sensitivity_specificity_support(
             y_true,
             y_pred,

--- a/imblearn/metrics/tests/test_classification.py
+++ b/imblearn/metrics/tests/test_classification.py
@@ -229,9 +229,13 @@ def test_geometric_mean_multiclass(y_true, y_pred, correction, expected_gmean):
 @pytest.mark.parametrize(
     "y_true, y_pred, average, expected_gmean",
     [
-        ([0, 1, 2, 0, 1, 2], [0, 2, 1, 0, 0, 1], "macro", 0.471),
+        # Macro / weighted G-mean is the (weighted) mean of the per-class
+        # G-mean array — which for this input is [0.866, 0, 0]. Their
+        # value is therefore 0.866/3 = 0.2887, NOT sqrt(macro_sen *
+        # macro_spe) = 0.471 as the metric used to return before #1096.
+        ([0, 1, 2, 0, 1, 2], [0, 2, 1, 0, 0, 1], "macro", 0.2887),
         ([0, 1, 2, 0, 1, 2], [0, 2, 1, 0, 0, 1], "micro", 0.471),
-        ([0, 1, 2, 0, 1, 2], [0, 2, 1, 0, 0, 1], "weighted", 0.471),
+        ([0, 1, 2, 0, 1, 2], [0, 2, 1, 0, 0, 1], "weighted", 0.2887),
         ([0, 1, 2, 0, 1, 2], [0, 2, 1, 0, 0, 1], None, [0.8660254, 0.0, 0.0]),
     ],
 )
@@ -251,12 +255,18 @@ def test_geometric_mean_average(y_true, y_pred, average, expected_gmean):
             "multiclass",
             0.707,
         ),
+        # weighted G-mean with labels=[0, 1] and the given sample
+        # weights: per-class (sen, spe) restricted to [0, 1] are
+        # [(1.0, 0.5), (0.5, 0.0)] with supports [2, 4]; per-class
+        # G-means = [sqrt(0.5), 0] = [0.707, 0]; weighted average =
+        # (2*0.707 + 4*0)/6 = 0.236. Old expected 0.333 came from
+        # sqrt(weighted_sen * weighted_spe), the bug fixed in #1096.
         (
             [0, 1, 2, 0, 1, 2],
             [0, 1, 1, 0, 0, 1],
             [1, 2, 1, 1, 2, 1],
             "weighted",
-            0.333,
+            0.236,
         ),
     ],
 )
@@ -278,8 +288,13 @@ def test_geometric_mean_sample_weight(
     [
         ("multiclass", 0.36),
         (None, [0.82, 0.24, 0.72]),
-        ("macro", 0.67),
-        ("weighted", 0.64),
+        # macro / weighted updated in #1096: now mean(per-class gmean)
+        # rather than sqrt(macro_sen * macro_spe). Per-class G-means
+        # for this fixture are [0.82, 0.24, 0.72]; macro = mean = 0.59;
+        # weighted mean over class supports (which differ slightly due
+        # to the 50/50 train/test split) = 0.55.
+        ("macro", 0.59),
+        ("weighted", 0.55),
     ],
 )
 def test_geometric_mean_score_prediction(average, expected_gmean):
@@ -287,6 +302,29 @@ def test_geometric_mean_score_prediction(average, expected_gmean):
 
     gmean = geometric_mean_score(y_true, y_pred, average=average)
     assert gmean == pytest.approx(expected_gmean, rel=R_TOL)
+
+
+@pytest.mark.parametrize(
+    "y_true, y_pred",
+    [
+        # binary case from #1096
+        ([0, 0, 1, 0, 1, 1], [0, 0, 0, 0, 0, 1]),
+        # binary, fully balanced
+        ([0, 1, 0, 1], [0, 1, 1, 0]),
+        # 3-class, asymmetric errors
+        ([0, 1, 2, 0, 1, 2], [0, 2, 1, 0, 1, 2]),
+    ],
+)
+def test_geometric_mean_macro_equals_mean_of_per_class(y_true, y_pred):
+    # Non-regression test for #1096: the macro G-mean MUST equal the
+    # arithmetic mean of the per-class G-mean array. Before #1096 the
+    # macro path returned sqrt(macro_sen * macro_spe), which generally
+    # disagrees with mean(per_class_gmean) — most visibly on binary
+    # inputs, where the original report observed 0.745 (correct ~0.577)
+    # for y_true=[0,0,1,0,1,1], y_pred=[0,0,0,0,0,1].
+    per_class = geometric_mean_score(y_true, y_pred, average=None)
+    macro = geometric_mean_score(y_true, y_pred, average="macro")
+    assert macro == pytest.approx(np.mean(per_class))
 
 
 def test_iba_geo_mean_binary():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue

Fixes #1096

#### What does this implement/fix? Explain your changes.

`geometric_mean_score(y_true, y_pred, average='macro')` did not return
the (arithmetic) mean of the per-class G-means as users expect.
Concretely, on the binary example from #1096 it returned **0.745** even
though the per-class array was `[0.577, 0.577]` (mean = 0.577).

The cause is in `imblearn/metrics/_classification.py`. For
`average in (None, 'binary', 'micro', 'macro', 'weighted', 'samples')`
the previous code did:

```python
sen, spe, _ = sensitivity_specificity_support(..., average=average)
return np.sqrt(sen * spe)
```

For `average='macro'`, `sensitivity_specificity_support` returns the
**macro-averaged** sensitivity and specificity as scalars — taking
`sqrt(sen * spe)` of those gives the geometric mean of mean-sensitivity
and mean-specificity, NOT the mean of per-class G-means. The two
disagree whenever the per-class (sen, spe) pairs are not all equal.
This is most visible on binary inputs where the macro path collapses to
a single (sen, spe) pair, but it also affects multi-class inputs.

The fix special-cases `macro` and `weighted`: it computes the per-class
sensitivity and specificity (`average=None`), derives the per-class
G-mean array, then aggregates with `np.mean` (macro) or
`np.average(weights=support)` (weighted). The resulting macro G-mean
exactly equals `np.mean(geometric_mean_score(..., average=None))`. The
`binary`, `micro`, `samples`, `None`, and `multiclass` branches are
unchanged.

##### Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/scikit-learn-contrib/imbalanced-learn.git /tmp/repro-1096 && cd /tmp/repro-1096
python -m venv .venv && source .venv/bin/activate
pip install -q -e '.[tests]'

# --- BEFORE (origin/master) ---
git checkout origin/master
python -c "
import numpy as np
from imblearn.metrics import geometric_mean_score
y_true = [0, 0, 1, 0, 1, 1]; y_pred = [0, 0, 0, 0, 0, 1]
per_class = geometric_mean_score(y_true, y_pred, average=None)
macro = geometric_mean_score(y_true, y_pred, average='macro')
print(f'per-class: {per_class}, macro: {macro:.4f}, mean: {np.mean(per_class):.4f}')
"
# Expected: per-class: [0.5774 0.5774], macro: 0.7454, mean: 0.5774
#   (macro disagrees with mean of per-class)

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/imbalanced-learn.git feat/1096-fix-gmean-macro-binary
git checkout FETCH_HEAD
python -c "
import numpy as np
from imblearn.metrics import geometric_mean_score
y_true = [0, 0, 1, 0, 1, 1]; y_pred = [0, 0, 0, 0, 0, 1]
per_class = geometric_mean_score(y_true, y_pred, average=None)
macro = geometric_mean_score(y_true, y_pred, average='macro')
print(f'per-class: {per_class}, macro: {macro:.4f}, mean: {np.mean(per_class):.4f}')
"
# Expected: per-class: [0.5774 0.5774], macro: 0.5774, mean: 0.5774
#   (macro now equals mean of per-class)
```

##### What I ran locally

- `pytest imblearn/metrics/` → 210 passed (208 existing + 2
  new parametrised case in
  `test_geometric_mean_macro_equals_mean_of_per_class`).
- The new parametrised non-regression test
  `test_geometric_mean_macro_equals_mean_of_per_class` fails on
  `origin/master` for two of the three input shapes (the binary case
  from #1096 plus a 3-class asymmetric case), confirming the bug
  reaches beyond binary.
- Updated stale expected values in
  `test_geometric_mean_average` (`macro` 0.471 → 0.2887,
  `weighted` 0.471 → 0.2887), `test_geometric_mean_sample_weight`
  (`weighted` 0.333 → 0.236), and `test_geometric_mean_score_prediction`
  (`macro` 0.67 → 0.59, `weighted` 0.64 → 0.55), each with an
  inline comment explaining the math so a reviewer can re-derive
  without trusting the diff.
- Doctest in the `geometric_mean_score` docstring updated:
  `macro` 0.471 → 0.288, `weighted` 0.471 → 0.288.

##### Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Binary, asymmetric per-class (#1096 case) | `[0,0,1,0,1,1], [0,0,0,0,0,1]` | macro = mean = 0.577 | `test_geometric_mean_macro_equals_mean_of_per_class[case-0]` |
| 2 | 3-class, asymmetric errors | `[0,1,2,0,1,2], [0,2,1,0,1,2]` | macro = mean(per-class) = 0.742 | `test_geometric_mean_macro_equals_mean_of_per_class[case-2]` |
| 3 | Binary, fully-balanced | `[0,1,0,1], [0,1,1,0]` | macro = mean = 0.5 (sanity) | `test_geometric_mean_macro_equals_mean_of_per_class[case-1]` |
| 4 | `average='micro'`, `'binary'`, `None`, `'multiclass'` | various | unchanged from previous behaviour | existing tests still green |

##### Risk / blast radius

Behavioural change for callers using `average='macro'` or
`'weighted'`. The previous numbers were not a documented invariant —
they were buggy — but downstream code that asserted on the old values
will need to update. The doctest and existing parametrised tests in the
suite have been updated in this PR to reflect the correct values, with
inline comments explaining the math.

`average='binary'`, `'micro'`, `None`, and `'multiclass'` are
unchanged.

#### Any other comments?

- Changelog entry added under "Bug fixes" in `doc/whats_new/v0.15.rst`
  with `:pr:\`0\``; I'll push a follow-up commit with the real PR
  number once GitHub assigns one (`check-changelog.yml` requires it
  whenever tests are modified).
- `[MRG]` prefix on the title.

```release-note
FIX :func:`imblearn.metrics.geometric_mean_score` with
``average='macro'`` (and ``'weighted'``) now returns the (weighted)
mean of the per-class G-mean array, consistent with
``np.mean(geometric_mean_score(..., average=None))``. The previous
behaviour returned ``sqrt(macro_sen * macro_spe)``.
```

---

*PR drafted with assistance from Claude Code. The change was reviewed
manually against scikit-learn-contrib/imbalanced-learn's source and the
upstream spec/docs cited above. The reproducer block above was used
during development; it is the same one a reviewer can paste verbatim.*
