### PR TITLE
[MRG] DOC explain shrinkage parameter origin in RandomOverSampler (#1030)

### DIFF
--- a/imblearn/over_sampling/_random_over_sampler.py
+++ b/imblearn/over_sampling/_random_over_sampler.py
@@ -39,7 +39,7 @@ class RandomOverSampler(BaseOverSampler):
     {random_state}
 
     shrinkage : float or dict, default=None
-        Parameter controlling the shrinkage applied to the covariance matrix.
+        Parameter controlling the shrinkage applied to the covariance matrix
         when a smoothed bootstrap is generated. The options are:
 
         - if `None`, a normal bootstrap will be generated without perturbation.
@@ -52,6 +52,18 @@ class RandomOverSampler(BaseOverSampler):
 
         The value needs of the shrinkage parameter needs to be higher or equal
         to 0.
+
+        Note that this parameter does not appear in the original ROSE
+        paper [1]_. It plays the role of a smoothing bandwidth on the
+        kernel-density bootstrap (analogous to the *learning_rate* /
+        shrinkage in gradient boosting and to shrunk-covariance
+        estimation): ``shrinkage=0`` (or ``None``) recovers ordinary
+        random over-sampling without perturbation, while increasing
+        ``shrinkage`` widens the smoothing kernel and yields the ROSE
+        smoothed bootstrap. A single parameter therefore selects between
+        plain random over-sampling and ROSE without exposing two
+        separate classes to the user. See discussion in
+        scikit-learn-contrib/imbalanced-learn#1030.
 
         .. versionadded:: 0.8
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue

Fixes #1030

#### What does this implement/fix? Explain your changes.

Issue #1030 reports that the `shrinkage` parameter of
`RandomOverSampler` has no mention in the cited ROSE paper
(Menardi & Torelli 2014), and asks for a reference. As @glemaitre
explained in-thread:

> I think I found that this parameter was behaving the same way as the
> `learning_rate` in GBDT, also known as shrinkage. You also have the
> concept of shrunk covariance that based on the value of the shrinkage
> your "shrink" the empirical covariance to an identity matrix.
>
> And the reason why this parameter is not in the paper is just because
> this single parameter can switch from the normal random over-sampling
> to ROSE without the need to create a dedicated class.

This PR formalises that explanation in the `shrinkage` docstring so a
future reader does not have to dig through the issue tracker. Pure doc
change — no behavioural or test impact.

A small typo (`. when` → `when`) at the end of the first line of the
docstring is fixed at the same time.

##### Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
git clone https://github.com/scikit-learn-contrib/imbalanced-learn.git /tmp/repro-1030 && cd /tmp/repro-1030

# --- BEFORE (origin/master) ---
git checkout origin/master
python -c "from imblearn.over_sampling import RandomOverSampler as R; print(R.__doc__.split('shrinkage : float or dict')[1].split('Attributes')[0])"
# Expected: docstring stops at "needs to be higher or equal to 0." with no
# explanation of why shrinkage is absent from the cited paper.

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/imbalanced-learn.git feat/1030-doc-shrinkage-reference
git checkout FETCH_HEAD
python -c "from imblearn.over_sampling import RandomOverSampler as R; print(R.__doc__.split('shrinkage : float or dict')[1].split('Attributes')[0])"
# Expected: extended explanation noting the analogy to GBDT learning_rate
# / shrunk-covariance, and why a single parameter switches between random
# over-sampling and ROSE without exposing two classes.
```

##### What I ran locally

- `pytest imblearn/over_sampling/tests/test_random_over_sampler.py` →
  29 passed (no behavioural change, just docstring text).

##### Edge cases tested

| # | Scenario | Verified by |
|---|----------|-------------|
| 1 | Pure docstring change; module still imports | `pytest imblearn/over_sampling/tests/test_random_over_sampler.py` 29/29 |

(Trivial fix; collapsed to a single row per the contribution-kit
"trivial fix → 1 row" guidance.)

##### Risk / blast radius

None. Docstring text only — no API, no semantics, no exports.

#### Any other comments?

- Pure documentation change; no test files modified, so the
  `check-changelog` action does not require a changelog entry. None
  added — happy to add one if a maintainer prefers.
- `[MRG]` prefix on the title.

```release-note
DOC explain that the ``shrinkage`` parameter of
:class:`imblearn.over_sampling.RandomOverSampler` plays the role of a
smoothing-bandwidth on the kernel-density bootstrap, analogous to the
``learning_rate`` in gradient boosting; ``shrinkage=0`` recovers
ordinary random over-sampling, while increasing it yields the ROSE
smoothed bootstrap.
```

---

*PR drafted with assistance from Claude Code. The change was reviewed
manually against scikit-learn-contrib/imbalanced-learn's source and the
upstream spec/docs cited above. The reproducer block above was used
during development; it is the same one a reviewer can paste verbatim.*
