### PR TITLE
FIX KMeansSMOTE: uniform weights for degenerate clusters (#1186)

### DIFF
--- a/doc/whats_new/v0.15.rst
+++ b/doc/whats_new/v0.15.rst
@@ -11,6 +11,12 @@ Changelog
 Bug fixes
 .........
 
+- Fix a bug in :class:`~imblearn.over_sampling.KMeansSMOTE` where degenerate
+  clusters -- every sample identical, hence zero sparsity -- produced ``NaN``
+  cluster weights and crashed with ``ValueError: cannot convert float NaN to
+  integer``. Such clusters are now weighted uniformly.
+  :pr:`1187` by :user:`chaoz23`.
+
 Enhancements
 ............
 

--- a/imblearn/over_sampling/_smote/cluster.py
+++ b/imblearn/over_sampling/_smote/cluster.py
@@ -264,7 +264,6 @@ class KMeansSMOTE(BaseSMOTE):
                 cluster_sparsities.append(self._find_cluster_sparsity(X_cluster_class))
 
             cluster_sparsities = np.array(cluster_sparsities)
-            cluster_weights = cluster_sparsities / cluster_sparsities.sum()
 
             if not valid_clusters:
                 raise RuntimeError(
@@ -273,6 +272,19 @@ class KMeansSMOTE(BaseSMOTE):
                     "cluster_balance_threshold or increasing the number of "
                     "clusters."
                 )
+
+            sparsity_sum = cluster_sparsities.sum()
+            if sparsity_sum == 0:
+                # All valid clusters are degenerate: every sample within each
+                # cluster is identical, so the pairwise distances -- and hence
+                # the sparsities -- are all zero. Dividing by the (zero) sum
+                # would yield NaN weights and later crash ``math.ceil``. Fall
+                # back to weighting the valid clusters uniformly.
+                cluster_weights = np.full(
+                    len(cluster_sparsities), 1 / len(cluster_sparsities)
+                )
+            else:
+                cluster_weights = cluster_sparsities / sparsity_sum
 
             for valid_cluster_idx, valid_cluster in enumerate(valid_clusters):
                 X_cluster = _safe_indexing(X, valid_cluster)

--- a/imblearn/over_sampling/_smote/tests/test_kmeans_smote.py
+++ b/imblearn/over_sampling/_smote/tests/test_kmeans_smote.py
@@ -93,6 +93,27 @@ def test_sample_kmeans_not_enough_clusters(data):
         smote.fit_resample(X, y)
 
 
+def test_sample_kmeans_degenerate_clusters():
+    """Check that identical samples within every valid cluster do not raise.
+
+    Non-regression test for
+    https://github.com/scikit-learn-contrib/imbalanced-learn/issues/1186:
+    when all valid clusters are degenerate (every point identical), their
+    sparsities are all zero and the weights used to be ``NaN``, crashing
+    ``math.ceil`` with ``ValueError: cannot convert float NaN to integer``.
+    """
+    X = np.array([[1.0, 1.0]] * 4 + [[2.0, 2.0]] * 4 + [[3.0, 3.0]] * 4)
+    y = np.array([1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0])
+    smote = KMeansSMOTE(
+        kmeans_estimator=KMeans(n_clusters=2, random_state=42),
+        random_state=42,
+        cluster_balance_threshold=0.1,
+    )
+    X_res, y_res = smote.fit_resample(X, y)
+    # the minority class has been oversampled up to the majority count
+    assert (y_res == 1).sum() == (y_res == 0).sum()
+
+
 @pytest.mark.parametrize("density_exponent", ["auto", 10])
 @pytest.mark.parametrize("cluster_balance_threshold", ["auto", 0.1])
 def test_sample_kmeans_density_estimation(density_exponent, cluster_balance_threshold):


### PR DESCRIPTION
Toward #1186 — fixes the crash (issue 1). The exact-count allocation (issue 2) is intentionally left as a follow-up, so this does **not** auto-close the issue.

#### What
When every sample within each valid cluster is identical, all cluster sparsities are `0`, so `cluster_sparsities / cluster_sparsities.sum()` divides by zero and yields `NaN` weights. The subsequent `math.ceil(...)` then raises `ValueError: cannot convert float NaN to integer`.

This can happen with duplicated rows or discrete/one-hot features where a whole cluster collapses to a single point.

#### Change
- Weight such degenerate clusters **uniformly** when the total sparsity is `0`, instead of dividing by zero.
- Move the existing empty-`valid_clusters` `RuntimeError` guard ahead of the weight computation (previously it ran an unnecessary division on an empty array first).
- Add a non-regression test reproducing the reported case.

#### Reproducer (from the issue)
```python
import numpy as np
from imblearn.over_sampling import KMeansSMOTE
from sklearn.cluster import KMeans

X = np.array([[1., 1.]]*4 + [[2., 2.]]*4 + [[3., 3.]]*4)
y = np.array([1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0])
KMeansSMOTE(
    kmeans_estimator=KMeans(n_clusters=2, random_state=42),
    random_state=42, cluster_balance_threshold=0.1,
).fit_resample(X, y)   # was: ValueError; now: resamples cleanly
```

#### Scope
Limited to issue 1 (the crash). Issue 2 (making the total number of generated samples exactly match the requested count) is a separate behavioral change — happy to follow up on it in its own PR.
