### PR TITLE
MAINT replace deprecated scipy distance_matrix with cdist

### DIFF
--- a/doc/whats_new/v0.15.rst
+++ b/doc/whats_new/v0.15.rst
@@ -17,5 +17,12 @@ Enhancements
 Compatibility
 .............
 
+- Replace the deprecated ``scipy.spatial.distance_matrix`` with
+  ``scipy.spatial.distance.cdist`` (Minkowski metric) in
+  :class:`~imblearn.metrics.pairwise.ValueDifferenceMetric`. This silences a
+  ``DeprecationWarning`` under SciPy 1.18 (the function is scheduled for
+  removal in SciPy 1.20); the computed distances are unchanged.
+  :pr:`1188` by :user:`chaoz23`.
+
 Deprecations
 ............

--- a/imblearn/metrics/pairwise.py
+++ b/imblearn/metrics/pairwise.py
@@ -6,7 +6,7 @@
 import numbers
 
 import numpy as np
-from scipy.spatial import distance_matrix
+from scipy.spatial.distance import cdist
 from sklearn.base import BaseEstimator
 from sklearn.utils import check_consistent_length
 from sklearn.utils._param_validation import StrOptions
@@ -227,7 +227,8 @@ class ValueDifferenceMetric(BaseEstimator):
             else:
                 proba_feature_Y = proba_feature_X
             distance += (
-                distance_matrix(proba_feature_X, proba_feature_Y, p=self.k) ** self.r
+                cdist(proba_feature_X, proba_feature_Y, metric="minkowski", p=self.k)
+                ** self.r
             )
         return distance
 


### PR DESCRIPTION
#### What
SciPy 1.18 deprecates `scipy.spatial.distance_matrix` in favour of `scipy.spatial.distance.cdist` (scheduled for removal in SciPy 1.20). `ValueDifferenceMetric.pairwise` still calls it, so under SciPy ≥ 1.18 it emits a `DeprecationWarning` — which currently fails the SMOTEN test suite (warnings are treated as errors).

#### Change
Switch the call to `cdist(..., metric="minkowski", p=self.k)`, which computes the identical Minkowski-p distance matrix.

#### Verification
- Numerical equivalence checked directly: `distance_matrix` vs `cdist(metric="minkowski")` match exactly (max abs diff `0.0`) for `p = 1, 2, 3`.
- `imblearn/metrics/tests/test_pairwise.py` — 132 passed (VDM results unchanged).
- `imblearn/over_sampling/_smote/tests/test_smoten.py` — 5 passed (previously failing on the deprecation).
- `ruff` and `black` clean.

No behavioural change; distances are identical.
